### PR TITLE
Add custom parser columns and +/- column syntax to -c/--columns

### DIFF
--- a/src/scans2any/helpers/cli.py
+++ b/src/scans2any/helpers/cli.py
@@ -12,7 +12,10 @@ from scans2any.filters import avail_filters
 from scans2any.helpers.utils import validate_columns
 from scans2any.internal import printer
 from scans2any.internal.protocols import HasAddArguments
-from scans2any.parsers import avail_parsers
+from scans2any.parsers import (
+    avail_parsers,
+    parser_custom_columns,
+)
 from scans2any.writers import avail_writers
 
 
@@ -228,12 +231,17 @@ def _add_writer_arguments(parser):
         default=False,
         help="Creates one table for each host, if supported by output format",
     )
+    default_cols = ("IP-Addresses", "Hostnames", "Ports", "Services", "Banners", "OS")
     writer_group.add_argument(
         "-c",
         "--columns",
-        type=lambda s: validate_columns(tuple(s.split(","))),
-        default=("IP-Addresses", "Hostnames", "Ports", "Services", "Banners", "OS"),
-        help="Specify output columns as a comma-separated list. (default: ('IP-Addresses', 'Hostnames', 'Ports', 'Services', 'Banners', 'OS'))",
+        type=lambda s: validate_columns(
+            tuple(s.split(",")),
+            extra_columns=parser_custom_columns,
+            default_columns=default_cols,
+        ),
+        default=default_cols,
+        help="Specify output columns as a comma-separated list. Use + or - to add or remove columns (e.g. +CVE,-OS).",
     )
     writer_group.add_argument(
         "-W",


### PR DESCRIPTION
- Import parser_custom_columns from parsers so parser-specific fields (e.g. Nessus Vulnerability-Type, Aquatone HTTP-Status) are recognized as valid column names in -c/--columns
- Pass extra_columns and default_columns to validate_columns so the +/- relative syntax works (e.g. -c +CVE,-OS adds CVE and removes OS from the default column set)
- Update --columns help text to document the +/- syntax