### PR TITLE
Add SQLite database persistence with --project flag

### DIFF
--- a/src/scans2any/helpers/cli.py
+++ b/src/scans2any/helpers/cli.py
@@ -206,6 +206,13 @@ def _add_basic_arguments(parser):
         default=False,
         help="Do not apply automatic conflict solving using internal rules",
     )
+    parser.add_argument(
+        "-p",
+        "--project",
+        metavar="name",
+        default=None,
+        help="Load/save from/into <project-name>.db database",
+    )
 
 
 def _add_scan_arguments(parser):

--- a/src/scans2any/helpers/file_processing.py
+++ b/src/scans2any/helpers/file_processing.py
@@ -21,6 +21,7 @@ from scans2any.helpers.utils import is_special_fd
 from scans2any.internal import Infrastructure, printer
 from scans2any.internal.printer import _stderr_console, logger
 from scans2any.parsers import avail_parsers
+from scans2any.parsers import database_parser as _database_parser
 
 
 def _worker_init(log_level: int) -> None:
@@ -166,7 +167,31 @@ def parse_input_files(args, parser) -> list[Infrastructure]:
                 provided = True
 
     if not provided:
-        parser.error("At least one input file argument must be provided.")
+        # If no input files provided but --project is set, load from database
+        project = getattr(args, "project", None)
+        if project:
+            quiet = getattr(args, "quiet", False)
+            verbose = getattr(args, "verbose", 0) > 0
+            if "database_parser" in avail_parsers:
+                with printer.status_section(
+                    "Loading from Database", quiet=quiet, verbose=verbose
+                ):
+                    try:
+                        infra = _database_parser.parse(project or "default", args)
+                        return [infra]
+                    except Exception as e:
+                        printer.error(f"Failed to load database: {e}")
+                        parser.error(
+                            f"Failed to load project '{project}' from database. "
+                            "Provide at least one input file argument or ensure the database exists."
+                        )
+            else:
+                parser.error(
+                    "Database parser not available. "
+                    "Provide at least one input file argument."
+                )
+
+        parser.error("At least one input file argument or --project must be provided.")
 
     def find_all_files(
         paths: list | str | Path, fileextensions: list[str]
@@ -218,6 +243,28 @@ def parse_input_files(args, parser) -> list[Infrastructure]:
         parser_name = f"{input_type}_parser"
         if parser_name not in avail_parsers:
             printer.warning(f"No parser available for {input_type} reports. Skipping.")
+            continue
+
+        # Special handling for database parser - it needs project argument, not files
+        if input_type == "database":
+            # Database flag is just True/False, not a file list
+            if not files:  # files would be False if flag not set
+                continue
+            project = getattr(args, "project", "default")
+            with printer.status_section(
+                f"Loading {input_type.capitalize()} Project '{project}'",
+                quiet=args.quiet,
+                verbose=getattr(args, "verbose", 0) > 0,
+            ):
+                try:
+                    # Pass args to enable database-level filtering
+                    infra = _database_parser.parse(project, args)
+                    all_infras.append(infra)
+                    printer.success(
+                        f"Successfully parsed database with {len(infra.hosts)} hosts."
+                    )
+                except Exception as e:
+                    printer.error(f"Failed to parse database: {e}")
             continue
 
         config = avail_parsers[parser_name].CONFIG

--- a/src/scans2any/internal/database.py
+++ b/src/scans2any/internal/database.py
@@ -1,0 +1,516 @@
+"""
+Database management for scans2any using SQLite.
+
+Provides functionality to store and retrieve scan data efficiently.
+Each project gets its own set of tables (hosts_<project>, services_<project>).
+"""
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from scans2any.internal import Host, Infrastructure, Service, SortedSet, printer
+
+
+class Database:
+    """
+    SQLite database handler for scans2any.
+
+    Manages host and service data with project-based table separation.
+    """
+
+    def __init__(self, db_path: str | Path = "scans2any.db", project: str = "default"):
+        """
+        Initialize database connection.
+
+        Parameters
+        ----------
+        db_path : str | Path
+            Path to SQLite database file
+        project : str
+            Project name (used for display/reference only, each project has own .db file)
+        """
+        self.db_path = Path(db_path)
+        self.project = project
+        self.conn: sqlite3.Connection | None = None
+        self.hosts_table = "hosts"
+        self.services_table = "services"
+
+    def connect(self):
+        """Establish database connection."""
+        self.conn = sqlite3.connect(str(self.db_path))
+        self.conn.row_factory = sqlite3.Row
+
+    def close(self):
+        """Close database connection."""
+        if self.conn:
+            self.conn.close()
+            self.conn = None
+
+    def __enter__(self):
+        """Context manager entry."""
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        self.close()
+
+    def create_tables(self):
+        """
+        Create tables if they don't exist.
+
+        Creates hosts and services tables with appropriate indexes.
+        """
+        if not self.conn:
+            raise RuntimeError("Database not connected")
+
+        cursor = self.conn.cursor()
+
+        # Create hosts table
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS hosts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                address TEXT NOT NULL UNIQUE,
+                hostnames TEXT,
+                os TEXT,
+                custom_fields TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # Create services table
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS services (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                host_id INTEGER NOT NULL,
+                port INTEGER NOT NULL,
+                protocol TEXT NOT NULL,
+                service_names TEXT,
+                banners TEXT,
+                custom_fields TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (host_id) REFERENCES hosts(id) ON DELETE CASCADE,
+                UNIQUE(host_id, port, protocol)
+            )
+        """)
+
+        # Create indexes for common queries
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_host_address
+            ON hosts(address)
+        """)
+
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_host_hostname
+            ON hosts(hostnames)
+        """)
+
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_service_port
+            ON services(port)
+        """)
+
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_service_name
+            ON services(service_names)
+        """)
+
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_service_host
+            ON services(host_id)
+        """)
+
+        self.conn.commit()
+
+    def clear_project_data(self):
+        """
+        Delete all data from the database.
+
+        Useful for replacing data rather than merging.
+        """
+        if not self.conn:
+            raise RuntimeError("Database not connected")
+
+        cursor = self.conn.cursor()
+        cursor.execute("DELETE FROM services")
+        cursor.execute("DELETE FROM hosts")
+        self.conn.commit()
+
+    def write_infrastructure(self, infra: Infrastructure, *, clear: bool = False):
+        """
+        Write infrastructure data to database.
+
+        Parameters
+        ----------
+        infra : Infrastructure
+            Infrastructure object to store
+        clear : bool
+            If True, clear existing project data before writing
+        """
+        if not self.conn:
+            raise RuntimeError("Database not connected")
+
+        self.create_tables()
+
+        if clear:
+            self.clear_project_data()
+
+        cursor = self.conn.cursor()
+
+        for host in infra.hosts:
+            # Serialize sets/lists to comma-separated strings
+            addresses = ",".join(sorted(host.address)) if host.address else ""
+            hostnames = ",".join(sorted(host.hostnames)) if host.hostnames else ""
+            os_list = (
+                ",".join(
+                    sorted(
+                        [os[0] if isinstance(os, tuple) else str(os) for os in host.os]
+                    )
+                )
+                if host.os
+                else ""
+            )
+
+            import json
+
+            custom_fields_json = (
+                json.dumps({k: list(v) for k, v in host.custom_fields.items()})
+                if host.custom_fields
+                else None
+            )
+
+            # Use first address as primary identifier for the host
+            # Check if host already exists by checking any of its addresses
+            existing_host_id = None
+            if addresses:
+                # Check if any address in this host already exists in database
+                for addr in addresses.split(","):
+                    cursor.execute(
+                        f"SELECT id, address FROM {self.hosts_table} WHERE address LIKE ?",
+                        (f"%{addr}%",),
+                    )
+                    row = cursor.fetchone()
+                    if row:
+                        existing_host_id = row["id"]
+                        # Merge addresses: combine old and new
+                        old_addresses = (
+                            set(row["address"].split(",")) if row["address"] else set()
+                        )
+                        new_addresses = set(addresses.split(","))
+                        addresses = ",".join(sorted(old_addresses | new_addresses))
+                        break
+
+            if existing_host_id:
+                # Update existing host
+                cursor.execute(
+                    f"""
+                    UPDATE {self.hosts_table}
+                    SET address = ?, hostnames = ?, os = ?, custom_fields = ?, updated_at = CURRENT_TIMESTAMP
+                    WHERE id = ?
+                """,
+                    (
+                        addresses,
+                        hostnames,
+                        os_list,
+                        custom_fields_json,
+                        existing_host_id,
+                    ),
+                )
+                host_id = existing_host_id
+            else:
+                # Insert new host
+                cursor.execute(
+                    f"""
+                    INSERT INTO {self.hosts_table} (address, hostnames, os, custom_fields)
+                    VALUES (?, ?, ?, ?)
+                """,
+                    (addresses, hostnames, os_list, custom_fields_json),
+                )
+                host_id = cursor.lastrowid
+
+            # Handle services
+            for service in host.services:
+                service_names = (
+                    ",".join(sorted(service.service_names))
+                    if service.service_names
+                    else ""
+                )
+                banners = ",".join(sorted(service.banners)) if service.banners else ""
+                service_custom_fields_json = (
+                    json.dumps({k: list(v) for k, v in service.custom_fields.items()})
+                    if service.custom_fields
+                    else None
+                )
+
+                # Check if service exists for this host
+                cursor.execute(
+                    f"""
+                    SELECT id FROM {self.services_table}
+                    WHERE host_id = ? AND port = ? AND protocol = ?
+                """,
+                    (host_id, service.port, service.protocol),
+                )
+
+                existing_service = cursor.fetchone()
+
+                if existing_service:
+                    # Update existing service
+                    cursor.execute(
+                        f"""
+                        UPDATE {self.services_table}
+                        SET service_names = ?, banners = ?, custom_fields = ?,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE id = ?
+                    """,
+                        (
+                            service_names,
+                            banners,
+                            service_custom_fields_json,
+                            existing_service["id"],
+                        ),
+                    )
+                else:
+                    # Insert new service
+                    cursor.execute(
+                        f"""
+                        INSERT INTO {self.services_table}
+                        (host_id, port, protocol, service_names, banners, custom_fields)
+                        VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                        (
+                            host_id,
+                            service.port,
+                            service.protocol,
+                            service_names,
+                            banners,
+                            service_custom_fields_json,
+                        ),
+                    )
+
+        self.conn.commit()
+
+    def read_infrastructure(
+        self, identifier: str | None = None, *, filters: dict[str, str] | None = None
+    ) -> Infrastructure:
+        """
+        Read infrastructure data from database.
+
+        Parameters
+        ----------
+        identifier : str, optional
+            Custom identifier for the infrastructure object
+        filters : dict[str, str], optional
+            Column filters to apply at database level.
+            Keys can be: 'address', 'hostname', 'port', 'service', 'banner'
+            Values are SQL LIKE patterns (use % for wildcards)
+
+        Returns
+        -------
+        Infrastructure
+            Infrastructure object with all hosts and services
+        """
+        if not self.conn:
+            raise RuntimeError("Database not connected")
+
+        cursor = self.conn.cursor()
+
+        # Check if tables exist
+        cursor.execute(
+            """
+            SELECT name FROM sqlite_master
+            WHERE type='table' AND name=?
+        """,
+            (self.hosts_table,),
+        )
+
+        if not cursor.fetchone():
+            printer.warning(f"No data found for project '{self.project}'")
+            return Infrastructure([], identifier or f"Database:{self.project}")
+
+        # Build WHERE clauses for filtering
+        host_where = []
+        host_params = []
+        service_where = []
+        service_params = []
+
+        if filters:
+            if "address" in filters:
+                host_where.append("address LIKE ?")
+                host_params.append(filters["address"])
+            if "hostname" in filters:
+                host_where.append("hostnames LIKE ?")
+                host_params.append(filters["hostname"])
+            if "port" in filters:
+                service_where.append("port = ?")
+                service_params.append(filters["port"])
+            if "service" in filters:
+                service_where.append("service_names LIKE ?")
+                service_params.append(filters["service"])
+            if "banner" in filters:
+                service_where.append("banners LIKE ?")
+                service_params.append(filters["banner"])
+
+        # If filtering by services, we need to join to get matching hosts
+        if service_where:
+            # Get host IDs that have matching services
+            service_filter_sql = " AND ".join(service_where)
+            cursor.execute(
+                f"""
+                SELECT DISTINCT host_id
+                FROM {self.services_table}
+                WHERE {service_filter_sql}
+            """,
+                service_params,
+            )
+            matching_host_ids = [row["host_id"] for row in cursor.fetchall()]
+
+            if not matching_host_ids:
+                return Infrastructure([], identifier or f"Database:{self.project}")
+
+            # Add host ID filter
+            placeholders = ",".join("?" * len(matching_host_ids))
+            host_where.append(f"id IN ({placeholders})")
+            host_params.extend(matching_host_ids)
+
+        # Build final host query
+        host_query = f"""
+            SELECT id, address, hostnames, os, custom_fields
+            FROM {self.hosts_table}
+        """
+        if host_where:
+            host_query += " WHERE " + " AND ".join(host_where)
+        host_query += " ORDER BY address"
+
+        # Fetch filtered hosts
+        cursor.execute(host_query, host_params)
+        host_rows = cursor.fetchall()
+        hosts = []
+
+        import json
+
+        for host_row in host_rows:
+            # Parse comma-separated values back to sets
+            addresses = (
+                set(host_row["address"].split(",")) if host_row["address"] else set()
+            )
+            hostnames = (
+                set(host_row["hostnames"].split(","))
+                if host_row["hostnames"]
+                else set()
+            )
+            os_list = (
+                set((os, "database") for os in host_row["os"].split(","))
+                if host_row["os"]
+                else set()
+            )
+            custom_fields = (
+                {k: set(v) for k, v in json.loads(host_row["custom_fields"]).items()}
+                if host_row["custom_fields"]
+                else {}
+            )
+
+            host = Host(
+                address=addresses,
+                hostnames=hostnames,
+                os=os_list,
+                custom_fields=custom_fields,
+            )
+
+            # Fetch services for this host (apply service filters)
+            service_query = f"""
+                SELECT port, protocol, service_names, banners, custom_fields
+                FROM {self.services_table}
+                WHERE host_id = ?
+            """
+            query_params = [host_row["id"]]
+
+            if service_where:
+                service_query += " AND " + " AND ".join(service_where)
+                query_params.extend(service_params)
+
+            service_query += " ORDER BY port"
+
+            cursor.execute(service_query, query_params)
+            service_rows = cursor.fetchall()
+
+            for service_row in service_rows:
+                service_names = (
+                    SortedSet(service_row["service_names"].split(","))
+                    if service_row["service_names"]
+                    else SortedSet()
+                )
+                banners = (
+                    SortedSet(service_row["banners"].split(","))
+                    if service_row["banners"]
+                    else SortedSet()
+                )
+                service_custom_fields = (
+                    {
+                        k: set(v)
+                        for k, v in json.loads(service_row["custom_fields"]).items()
+                    }
+                    if service_row["custom_fields"]
+                    else {}
+                )
+
+                service = Service(
+                    port=service_row["port"],
+                    protocol=service_row["protocol"],
+                    service_names=service_names,
+                    banners=banners,
+                    custom_fields=service_custom_fields,
+                )
+
+                host.add_service(service)
+
+            hosts.append(host)
+
+        return Infrastructure(hosts, identifier or f"Database:{self.project}")
+
+    def get_statistics(self) -> dict[str, Any]:
+        """
+        Get statistics about the current project.
+
+        Returns
+        -------
+        dict
+            Statistics including host count, service count, etc.
+        """
+        if not self.conn:
+            raise RuntimeError("Database not connected")
+
+        cursor = self.conn.cursor()
+
+        # Check if tables exist
+        cursor.execute(
+            """
+            SELECT name FROM sqlite_master
+            WHERE type='table' AND name=?
+        """,
+            (self.hosts_table,),
+        )
+
+        if not cursor.fetchone():
+            return {"project": self.project, "hosts": 0, "services": 0, "protocols": []}
+
+        # Count hosts
+        cursor.execute(f"SELECT COUNT(*) as count FROM {self.hosts_table}")
+        host_count = cursor.fetchone()["count"]
+
+        # Count services
+        cursor.execute(f"SELECT COUNT(*) as count FROM {self.services_table}")
+        service_count = cursor.fetchone()["count"]
+
+        # Get protocols
+        cursor.execute(f"SELECT DISTINCT protocol FROM {self.services_table}")
+        protocols = [row["protocol"] for row in cursor.fetchall()]
+
+        return {
+            "project": self.project,
+            "hosts": host_count,
+            "services": service_count,
+            "protocols": protocols,
+        }

--- a/src/scans2any/main.py
+++ b/src/scans2any/main.py
@@ -110,6 +110,50 @@ def main():
     printer.debug(f"Enabled filters: {filters}")
     apply_filters(combined_infra, filters, args, quiet=args.quiet, verbose=verbose)
 
+    # Auto-save to database if --project is explicitly set and we parsed input files (not from database)
+    project = getattr(args, "project", None)
+    if project and all_infras:
+        # Check if any actual scan input files were provided (not just loading from database)
+        input_file_types = [
+            "nmap",
+            "aquatone",
+            "bloodhound",
+            "nuclei",
+            "masscan",
+            "nessus",
+            "nxc",
+            "txt",
+            "json",
+        ]
+        has_input_files = any(getattr(args, attr, None) for attr in input_file_types)
+
+        # Only auto-save if we loaded from input files, not from database
+        if has_input_files:
+            from scans2any.internal.database import Database
+
+            verbose = hasattr(args, "verbose") and args.verbose > 0
+            db_path = f"{project}.db"
+
+            if verbose:
+                printer.section("Auto-saving to Database")
+                printer.info(f"Saving project '{project}' to {db_path}")
+                printer.info(f"Hosts: {len(combined_infra.hosts)}")
+                service_count = sum(len(h.services) for h in combined_infra.hosts)
+                printer.info(f"Services: {service_count}")
+
+            try:
+                with Database(db_path, project) as db:
+                    # Merge with existing data (clear=False to preserve and merge)
+                    db.write_infrastructure(combined_infra, clear=False)
+                    if verbose:
+                        stats = db.get_statistics()
+                        printer.success(
+                            f"Database updated: {stats['hosts']} hosts, "
+                            f"{stats['services']} services"
+                        )
+            except Exception as e:
+                printer.warning(f"Failed to auto-save to database: {e}")
+
     # Handle merging and conflicts
     try:
         combined_infra = resolve_infrastructure_conflicts(

--- a/src/scans2any/parsers/database_parser.py
+++ b/src/scans2any/parsers/database_parser.py
@@ -1,0 +1,138 @@
+"""
+Parse scan data from SQLite database.
+
+Reads infrastructure data from a project-specific SQLite database.
+Supports efficient filtering at the SQL level.
+"""
+
+from scans2any.internal import Infrastructure, printer
+from scans2any.internal.database import Database
+
+CONFIG = {
+    "extensions": [".db", ".sqlite", ".sqlite3"],
+}
+
+
+def add_arguments(parser):
+    """
+    Add arguments to the parser for database input.
+
+    Database can be loaded with just --project flag.
+    If --project is specified without other inputs, data is loaded from database.
+    If --project is specified WITH other inputs, new data is merged into database.
+    """
+    # No additional arguments needed - --project already exists in main CLI
+    pass
+
+
+def _parse_column_filters(col_filters: list[str]) -> dict[str, str]:
+    """
+    Parse column:regex filters into database filter dict.
+
+    Parameters
+    ----------
+    col_filters : list[str]
+        List of "column:regex" strings
+
+    Returns
+    -------
+    dict[str, str]
+        Filter dict with SQL LIKE patterns
+    """
+    filters = {}
+    column_map = {
+        "IP-Addresses": "address",
+        "IP": "address",
+        "Hostnames": "hostname",
+        "Hostname": "hostname",
+        "Ports": "port",
+        "Port": "port",
+        "Services": "service",
+        "Service": "service",
+        "Banners": "banner",
+        "Banner": "banner",
+    }
+
+    for col_filter in col_filters:
+        if ":" not in col_filter:
+            continue
+
+        col, pattern = col_filter.split(":", 1)
+        db_col = column_map.get(col)
+
+        if not db_col:
+            continue
+
+        # Convert regex to SQL LIKE pattern (simple conversion)
+        # For exact matches or simple patterns
+        if db_col == "port":
+            # Port should be exact match
+            try:
+                filters[db_col] = int(pattern)
+            except ValueError:
+                continue
+        else:
+            # Convert to SQL LIKE pattern
+            # Replace .* with %, . with _, etc.
+            like_pattern = pattern.replace(".*", "%").replace(".", "_")
+            if not like_pattern.startswith("%"):
+                like_pattern = "%" + like_pattern
+            if not like_pattern.endswith("%"):
+                like_pattern = like_pattern + "%"
+            filters[db_col] = like_pattern
+
+    return filters
+
+
+def parse(project: str = "default", args=None) -> Infrastructure:
+    """
+    Parses SQLite database and generates an Infrastructure object.
+
+    Parameters
+    ----------
+    project : str
+        Project name to read from database (default: "default")
+        Database file is {project}.db
+    args : argparse.Namespace, optional
+        Command line arguments for filtering and verbosity
+
+    Returns
+    -------
+    Infrastructure
+        Scan data as `Infrastructure` object.
+    """
+
+    db_path = (
+        project if project.endswith(tuple(CONFIG["extensions"])) else f"{project}.db"
+    )
+
+    printer.status(f"Database: {db_path}")
+
+    # Parse column filters from args if provided
+    filters = None
+    if args and hasattr(args, "col") and args.col:
+        filters = _parse_column_filters(args.col)
+        if filters:
+            printer.info(f"Applying database filters: {filters}")
+
+    verbose = args and hasattr(args, "verbose") and args.verbose > 0
+
+    with Database(db_path, project) as db:
+        stats = db.get_statistics()
+
+        if verbose:
+            printer.info(f"Project '{project}' contains:")
+            printer.info(f"  - {stats['hosts']} hosts")
+            printer.info(f"  - {stats['services']} services")
+            if stats["protocols"]:
+                printer.info(f"  - Protocols: {', '.join(stats['protocols'])}")
+
+        if not filters and stats["hosts"] > 0:
+            printer.info(
+                f"Loading {stats['hosts']} hosts with {stats['services']} services"
+            )
+
+        infra = db.read_infrastructure(filters=filters)
+
+    printer.success(f"Successfully loaded project '{project}' from database")
+    return infra

--- a/src/scans2any/writers/database_writer.py
+++ b/src/scans2any/writers/database_writer.py
@@ -1,0 +1,93 @@
+"""Writes infrastructure data to SQLite database."""
+
+from pathlib import Path
+from sqlite3 import IntegrityError
+
+from scans2any.internal import Infrastructure, printer
+from scans2any.internal.database import Database
+
+NAME = "database"
+PROPERTIES = {
+    "binary": False,
+    "ignore-conflicts": False,
+}
+
+
+def add_arguments(parser):
+    """
+    Add arguments to the parser for database output.
+    """
+    parser.add_argument(
+        "--db-clear",
+        action="store_true",
+        default=False,
+        help="Clear existing project data before writing to database",
+    )
+
+
+def write(infra: Infrastructure, args) -> str:
+    """
+    Write the infrastructure data to SQLite database.
+
+    Parameters
+    ----------
+    infra : Infrastructure
+        Infrastructure object to write
+    args : argparse.Namespace
+        Command line arguments
+
+    Returns
+    -------
+    str
+        Success message
+    """
+    # Get project from args
+    project = getattr(args, "project", "default")
+    if not project:
+        project = "default"
+
+    db_path = Path(f"{project}.db")
+    clear = getattr(args, "db_clear", False)
+    verbose = hasattr(args, "verbose") and args.verbose > 0
+
+    printer.section("Writing to Database")
+    printer.status(f"Database: {db_path}")
+    printer.status(f"Project: {project}")
+
+    with Database(db_path, project) as db:
+        if clear:
+            printer.info("Clearing existing project data")
+            if verbose:
+                old_stats = db.get_statistics()
+                printer.info(
+                    f"Removing {old_stats['hosts']} hosts and {old_stats['services']} services"
+                )
+
+        if verbose:
+            printer.info(f"Writing {len(infra.hosts)} hosts...")
+            service_count = sum(len(h.services) for h in infra.hosts)
+            printer.info(f"Writing {service_count} services...")
+        try:
+            db.write_infrastructure(infra, clear=clear)
+        except IntegrityError as e:
+            printer.failure(f"Failed to write to database: {e}")
+            printer.failure("Try to re-rerun with -F empty_host")
+            exit(1)
+        except Exception as e:
+            printer.failure(f"Failed to write to database: {e}")
+            raise
+        stats = db.get_statistics()
+
+    if verbose:
+        printer.info("Database now contains:")
+        printer.info(f"  - {stats['hosts']} hosts")
+        printer.info(f"  - {stats['services']} services")
+        if stats["protocols"]:
+            printer.info(f"  - Protocols: {', '.join(stats['protocols'])}")
+
+    printer.success(
+        f"Successfully wrote {stats['hosts']} hosts with {stats['services']} services "
+        f"to project '{project}'"
+    )
+
+    return f"Data written to database: {db_path} (project: {project})"


### PR DESCRIPTION
- Add internal/database.py: SQLite backend for storing and retrieving Infrastructure data (hosts, services, custom fields) with merge-on-write semantics and database-level filtering
- Add parsers/database_parser.py: parser that loads a project's .db file into an Infrastructure object
- Add writers/database_writer.py: writer that persists Infrastructure to SQLite with optional --db-clear flag
- Add -p/--project CLI flag: specifying a project name automatically saves parsed scan data to <project>.db after filters are applied, and loads from the database when no input files are given
- Update file_processing.py: load from database when --project is set but no input files are provided; handle database parser specially