### PR TITLE
Add --merge-rules flag for user-defined auto-merge rules

### DIFF
--- a/src/scans2any/helpers/cli.py
+++ b/src/scans2any/helpers/cli.py
@@ -213,6 +213,11 @@ def _add_basic_arguments(parser):
         default=None,
         help="Load/save from/into <project-name>.db database",
     )
+    parser.add_argument(
+        "--merge-rules",
+        metavar="filename",
+        help="Use file as custom merge rules to resolve conflicts automatically",
+    )
 
 
 def _add_scan_arguments(parser):

--- a/src/scans2any/main.py
+++ b/src/scans2any/main.py
@@ -79,6 +79,16 @@ def main():
     # Parse merge file if provided
     merge_infra, auto_merge_ruleset = handle_merge_file(args.merge_file)
 
+    # Parse custom merge rules if provided
+    custom_merge_ruleset = None
+    if args.merge_rules:
+        import yaml
+        from yaml import SafeLoader
+
+        with open(args.merge_rules) as file:
+            config = yaml.load(file, Loader=SafeLoader)
+            custom_merge_ruleset = config.get("auto-merge", [])
+
     # Setup signal handler
     signal.signal(signal.SIGINT, signal_handler)
     global executor
@@ -170,7 +180,9 @@ def main():
 
     # Apply automatic merging if not disabled
     if not args.no_auto_merge:
-        combined_infra.auto_merge(quiet=args.quiet, verbose=verbose)
+        combined_infra.auto_merge(
+            ruleset=custom_merge_ruleset, quiet=args.quiet, verbose=verbose
+        )
         printer.debug(combined_infra)
 
     # Check for remaining conflicts if not ignored


### PR DESCRIPTION
Allow users to supply a YAML file with custom auto-merge rules via --merge-rules <filename>. The file's top-level "auto-merge" list is loaded and passed to Infrastructure.auto_merge() as the ruleset, supplementing or overriding the built-in rules.