### PR TITLE
Update test suite: in-process mocking, new database and model tests

### DIFF
--- a/tests/__snapshots__/test_integration.ambr
+++ b/tests/__snapshots__/test_integration.ambr
@@ -1,0 +1,11173 @@
+# serializer version: 1
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w aquatone --multi-table]
+  '''
+  http://192.168.56.10:5985
+  http://192.168.56.10:5986
+  http://192.168.56.11:5985
+  http://192.168.56.11:5986
+  http://192.168.56.22:5985
+  http://192.168.56.22:5986
+  https://192.168.56.10:5985
+  https://192.168.56.10:5986
+  https://192.168.56.11:5985
+  https://192.168.56.11:5986
+  https://192.168.56.22:5985
+  https://192.168.56.22:5986
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w aquatone]
+  '''
+  http://192.168.56.10:5985
+  http://192.168.56.10:5986
+  http://192.168.56.11:5985
+  http://192.168.56.11:5986
+  http://192.168.56.22:5985
+  http://192.168.56.22:5986
+  https://192.168.56.10:5985
+  https://192.168.56.10:5986
+  https://192.168.56.11:5985
+  https://192.168.56.11:5986
+  https://192.168.56.22:5985
+  https://192.168.56.22:5986
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w csv --multi-table]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  192.168.56.10,,5985/tcp,http,Microsoft\-HTTPAPI/2.0,
+  192.168.56.10,,5986/tcp,https,Microsoft\-HTTPAPI/2.0,
+  192.168.56.11,,5985/tcp,http,Microsoft\-HTTPAPI/2.0,
+  192.168.56.11,,5986/tcp,https,Microsoft\-HTTPAPI/2.0,
+  192.168.56.22,,5985/tcp,http,Microsoft\-HTTPAPI/2.0,
+  192.168.56.22,,5986/tcp,https,Microsoft\-HTTPAPI/2.0,
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w csv]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  192.168.56.10,,5985/tcp,http,Microsoft\-HTTPAPI/2.0,
+  192.168.56.10,,5986/tcp,https,Microsoft\-HTTPAPI/2.0,
+  192.168.56.11,,5985/tcp,http,Microsoft\-HTTPAPI/2.0,
+  192.168.56.11,,5986/tcp,https,Microsoft\-HTTPAPI/2.0,
+  192.168.56.22,,5985/tcp,http,Microsoft\-HTTPAPI/2.0,
+  192.168.56.22,,5986/tcp,https,Microsoft\-HTTPAPI/2.0,
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w host --multi-table]
+  '''
+  192.168.56.10
+  192.168.56.11
+  192.168.56.22
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w host]
+  '''
+  192.168.56.10
+  192.168.56.11
+  192.168.56.22
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w html --multi-table]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.10</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>5985/tcp</td>
+        <td>http</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+      <tr>
+        <td>5986/tcp</td>
+        <td>https</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.11</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>5985/tcp</td>
+        <td>http</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+      <tr>
+        <td>5986/tcp</td>
+        <td>https</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.22</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>5985/tcp</td>
+        <td>http</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+      <tr>
+        <td>5986/tcp</td>
+        <td>https</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w html]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>IP-Addresses</th>
+        <th>Hostnames</th>
+        <th>Ports</th>
+        <th>Services</th>
+        <th>Banners</th>
+        <th>OS</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>192.168.56.10</td>
+        <td></td>
+        <td>5985/tcp<br>5986/tcp</td>
+        <td>http<br>https</td>
+        <td>Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>192.168.56.11</td>
+        <td></td>
+        <td>5985/tcp<br>5986/tcp</td>
+        <td>http<br>https</td>
+        <td>Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>192.168.56.22</td>
+        <td></td>
+        <td>5985/tcp<br>5986/tcp</td>
+        <td>http<br>https</td>
+        <td>Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w json --multi-table]
+  '''
+  {"192.168.56.10":{"hostnames":[],"tcp_ports":{"5985":{"service_names":["http"],"banners":["Microsoft-HTTPAPI\/2.0"]},"5986":{"service_names":["https"],"banners":["Microsoft-HTTPAPI\/2.0"]}},"udp_ports":{},"os":[]},"192.168.56.11":{"hostnames":[],"tcp_ports":{"5985":{"service_names":["http"],"banners":["Microsoft-HTTPAPI\/2.0"]},"5986":{"service_names":["https"],"banners":["Microsoft-HTTPAPI\/2.0"]}},"udp_ports":{},"os":[]},"192.168.56.22":{"hostnames":[],"tcp_ports":{"5985":{"service_names":["http"],"banners":["Microsoft-HTTPAPI\/2.0"]},"5986":{"service_names":["https"],"banners":["Microsoft-HTTPAPI\/2.0"]}},"udp_ports":{},"os":[]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w json]
+  '''
+  {"192.168.56.10":{"hostnames":[],"tcp_ports":{"5985":{"service_names":["http"],"banners":["Microsoft-HTTPAPI\/2.0"]},"5986":{"service_names":["https"],"banners":["Microsoft-HTTPAPI\/2.0"]}},"udp_ports":{},"os":[]},"192.168.56.11":{"hostnames":[],"tcp_ports":{"5985":{"service_names":["http"],"banners":["Microsoft-HTTPAPI\/2.0"]},"5986":{"service_names":["https"],"banners":["Microsoft-HTTPAPI\/2.0"]}},"udp_ports":{},"os":[]},"192.168.56.22":{"hostnames":[],"tcp_ports":{"5985":{"service_names":["http"],"banners":["Microsoft-HTTPAPI\/2.0"]},"5986":{"service_names":["https"],"banners":["Microsoft-HTTPAPI\/2.0"]}},"udp_ports":{},"os":[]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w latex --multi-table]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.10} & \makecell[l]{} & \makecell[l]{} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.10} & \makecell[l]{} & \makecell[l]{} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{5985/tcp} & \makecell[l]{http} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \makecell[l]{5986/tcp} & \makecell[l]{https} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \end{longtable}
+  
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.11} & \makecell[l]{} & \makecell[l]{} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.11} & \makecell[l]{} & \makecell[l]{} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{5985/tcp} & \makecell[l]{http} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \makecell[l]{5986/tcp} & \makecell[l]{https} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \end{longtable}
+  
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.22} & \makecell[l]{} & \makecell[l]{} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.22} & \makecell[l]{} & \makecell[l]{} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{5985/tcp} & \makecell[l]{http} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \makecell[l]{5986/tcp} & \makecell[l]{https} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w latex]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{llllll}
+  \caption{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{6}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{192.168.56.10} & \makecell[l]{} & \makecell[l]{5985/tcp \\ 5986/tcp} & \makecell[l]{http \\ https} & \makecell[l]{Microsoft-HTTPAPI/2.0 \\ Microsoft-HTTPAPI/2.0} & \makecell[l]{} \\
+  \makecell[l]{192.168.56.11} & \makecell[l]{} & \makecell[l]{5985/tcp \\ 5986/tcp} & \makecell[l]{http \\ https} & \makecell[l]{Microsoft-HTTPAPI/2.0 \\ Microsoft-HTTPAPI/2.0} & \makecell[l]{} \\
+  \makecell[l]{192.168.56.22} & \makecell[l]{} & \makecell[l]{5985/tcp \\ 5986/tcp} & \makecell[l]{http \\ https} & \makecell[l]{Microsoft-HTTPAPI/2.0 \\ Microsoft-HTTPAPI/2.0} & \makecell[l]{} \\
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w markdown --multi-table]
+  '''
+  | 192.168.56.10   |       |                       |
+  |:----------------|:------|:----------------------|
+  | 5985/tcp        | http  | Microsoft-HTTPAPI/2.0 |
+  | 5986/tcp        | https | Microsoft-HTTPAPI/2.0 |
+  
+  
+  | 192.168.56.11   |       |                       |
+  |:----------------|:------|:----------------------|
+  | 5985/tcp        | http  | Microsoft-HTTPAPI/2.0 |
+  | 5986/tcp        | https | Microsoft-HTTPAPI/2.0 |
+  
+  
+  | 192.168.56.22   |       |                       |
+  |:----------------|:------|:----------------------|
+  | 5985/tcp        | http  | Microsoft-HTTPAPI/2.0 |
+  | 5986/tcp        | https | Microsoft-HTTPAPI/2.0 |
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w markdown]
+  '''
+  | IP-Addresses   | Hostnames   | Ports                | Services      | Banners                                        | OS   |
+  |:---------------|:------------|:---------------------|:--------------|:-----------------------------------------------|:-----|
+  | 192.168.56.10  |             | 5985/tcp<br>5986/tcp | http<br>https | Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0 |      |
+  | 192.168.56.11  |             | 5985/tcp<br>5986/tcp | http<br>https | Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0 |      |
+  | 192.168.56.22  |             | 5985/tcp<br>5986/tcp | http<br>https | Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0 |      |
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w nmap --multi-table]
+  '''
+  #!/bin/sh
+  
+  nmap 192.168.56.10 -sS -A -Pn -n -T4 -oA 192.168.56.10 -p 5985,5986,5987
+  nmap 192.168.56.11 -sS -A -Pn -n -T4 -oA 192.168.56.11 -p 5985,5986,5987
+  nmap 192.168.56.22 -sS -A -Pn -n -T4 -oA 192.168.56.22 -p 5985,5986,5987
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w nmap]
+  '''
+  #!/bin/sh
+  
+  nmap 192.168.56.10 -sS -A -Pn -n -T4 -oA 192.168.56.10 -p 5985,5986,5987
+  nmap 192.168.56.11 -sS -A -Pn -n -T4 -oA 192.168.56.11 -p 5985,5986,5987
+  nmap 192.168.56.22 -sS -A -Pn -n -T4 -oA 192.168.56.22 -p 5985,5986,5987
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w terminal --multi-table]
+  '''
+  ╒═════════════════╤═══════╤═══════════════════════╕
+  │ 192.168.56.10   │       │                       │
+  ╞═════════════════╪═══════╪═══════════════════════╡
+  │ 5985/tcp        │ http  │ Microsoft-HTTPAPI/2.0 │
+  ├─────────────────┼───────┼───────────────────────┤
+  │ 5986/tcp        │ https │ Microsoft-HTTPAPI/2.0 │
+  ╘═════════════════╧═══════╧═══════════════════════╛
+  
+  ╒═════════════════╤═══════╤═══════════════════════╕
+  │ 192.168.56.11   │       │                       │
+  ╞═════════════════╪═══════╪═══════════════════════╡
+  │ 5985/tcp        │ http  │ Microsoft-HTTPAPI/2.0 │
+  ├─────────────────┼───────┼───────────────────────┤
+  │ 5986/tcp        │ https │ Microsoft-HTTPAPI/2.0 │
+  ╘═════════════════╧═══════╧═══════════════════════╛
+  
+  ╒═════════════════╤═══════╤═══════════════════════╕
+  │ 192.168.56.22   │       │                       │
+  ╞═════════════════╪═══════╪═══════════════════════╡
+  │ 5985/tcp        │ http  │ Microsoft-HTTPAPI/2.0 │
+  ├─────────────────┼───────┼───────────────────────┤
+  │ 5986/tcp        │ https │ Microsoft-HTTPAPI/2.0 │
+  ╘═════════════════╧═══════╧═══════════════════════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w terminal]
+  '''
+  ╒════════════════╤═════════════╤══════════╤════════════╤═══════════════════════╤══════╕
+  │ IP-Addresses   │ Hostnames   │ Ports    │ Services   │ Banners               │ OS   │
+  ╞════════════════╪═════════════╪══════════╪════════════╪═══════════════════════╪══════╡
+  │ 192.168.56.10  │             │ 5985/tcp │ http       │ Microsoft-HTTPAPI/2.0 │      │
+  │                │             │ 5986/tcp │ https      │ Microsoft-HTTPAPI/2.0 │      │
+  ├────────────────┼─────────────┼──────────┼────────────┼───────────────────────┼──────┤
+  │ 192.168.56.11  │             │ 5985/tcp │ http       │ Microsoft-HTTPAPI/2.0 │      │
+  │                │             │ 5986/tcp │ https      │ Microsoft-HTTPAPI/2.0 │      │
+  ├────────────────┼─────────────┼──────────┼────────────┼───────────────────────┼──────┤
+  │ 192.168.56.22  │             │ 5985/tcp │ http       │ Microsoft-HTTPAPI/2.0 │      │
+  │                │             │ 5986/tcp │ https      │ Microsoft-HTTPAPI/2.0 │      │
+  ╘════════════════╧═════════════╧══════════╧════════════╧═══════════════════════╧══════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w typst --multi-table]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (3),
+    [*192.168.56.10*], [**], [**],
+    [5985/tcp], [http], [Microsoft-HTTPAPI/2.0],
+    [5986/tcp], [https], [Microsoft-HTTPAPI/2.0]
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [*192.168.56.11*], [**], [**],
+    [5985/tcp], [http], [Microsoft-HTTPAPI/2.0],
+    [5986/tcp], [https], [Microsoft-HTTPAPI/2.0]
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [*192.168.56.22*], [**], [**],
+    [5985/tcp], [http], [Microsoft-HTTPAPI/2.0],
+    [5986/tcp], [https], [Microsoft-HTTPAPI/2.0]
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w typst]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (6),
+    [*IP-Addresses*], [*Hostnames*], [*Ports*], [*Services*], [*Banners*], [*OS*],
+    [192.168.56.10], [], [5985/tcp \ 5986/tcp], [http \ https], [Microsoft-HTTPAPI/2.0 \ Microsoft-HTTPAPI/2.0], [],
+    [192.168.56.11], [], [5985/tcp \ 5986/tcp], [http \ https], [Microsoft-HTTPAPI/2.0 \ Microsoft-HTTPAPI/2.0], [],
+    [192.168.56.22], [], [5985/tcp \ 5986/tcp], [http \ https], [Microsoft-HTTPAPI/2.0 \ Microsoft-HTTPAPI/2.0], []
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w url --multi-table]
+  '''
+  http://192.168.56.10:5985
+  http://192.168.56.11:5985
+  http://192.168.56.22:5985
+  https://192.168.56.10:5986
+  https://192.168.56.11:5986
+  https://192.168.56.22:5986
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w url]
+  '''
+  http://192.168.56.10:5985
+  http://192.168.56.11:5985
+  http://192.168.56.22:5985
+  https://192.168.56.10:5986
+  https://192.168.56.11:5986
+  https://192.168.56.22:5986
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w xml --multi-table]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="192.168.56.10">
+      <tcp_ports>
+        <port number="5985">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>https</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.11">
+      <tcp_ports>
+        <port number="5985">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>https</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.22">
+      <tcp_ports>
+        <port number="5985">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>https</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w xml]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="192.168.56.10">
+      <tcp_ports>
+        <port number="5985">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>https</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.11">
+      <tcp_ports>
+        <port number="5985">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>https</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.22">
+      <tcp_ports>
+        <port number="5985">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>https</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w yaml --multi-table]
+  '''
+  192.168.56.10:
+      hostnames: []
+      tcp_ports:
+          5985:
+              service_names:
+              - http
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          5986:
+              service_names:
+              - https
+              banners:
+              - Microsoft-HTTPAPI/2.0
+      udp_ports: {}
+      os: []
+  192.168.56.11:
+      hostnames: []
+      tcp_ports:
+          5985:
+              service_names:
+              - http
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          5986:
+              service_names:
+              - https
+              banners:
+              - Microsoft-HTTPAPI/2.0
+      udp_ports: {}
+      os: []
+  192.168.56.22:
+      hostnames: []
+      tcp_ports:
+          5985:
+              service_names:
+              - http
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          5986:
+              service_names:
+              - https
+              banners:
+              - Microsoft-HTTPAPI/2.0
+      udp_ports: {}
+      os: []
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/aquatone/goad-light-aquatone_session.json -w yaml]
+  '''
+  192.168.56.10:
+      hostnames: []
+      tcp_ports:
+          5985:
+              service_names:
+              - http
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          5986:
+              service_names:
+              - https
+              banners:
+              - Microsoft-HTTPAPI/2.0
+      udp_ports: {}
+      os: []
+  192.168.56.11:
+      hostnames: []
+      tcp_ports:
+          5985:
+              service_names:
+              - http
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          5986:
+              service_names:
+              - https
+              banners:
+              - Microsoft-HTTPAPI/2.0
+      udp_ports: {}
+      os: []
+  192.168.56.22:
+      hostnames: []
+      tcp_ports:
+          5985:
+              service_names:
+              - http
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          5986:
+              service_names:
+              - https
+              banners:
+              - Microsoft-HTTPAPI/2.0
+      udp_ports: {}
+      os: []
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--aquatone tests/data/ipv6/aquatone/aquatone_session.json -w terminal]
+  '''
+  ╒══════════════════════════╤═════════════╤═════════╤════════════╤══════════════╤══════╕
+  │ IP-Addresses             │ Hostnames   │ Ports   │ Services   │ Banners      │ OS   │
+  ╞══════════════════════════╪═════════════╪═════════╪════════════╪══════════════╪══════╡
+  │ 172.217.18.14            │ google.com  │ 80/tcp  │ http       │ Google | gws │      │
+  │ 2a00:1450:4001:80b::200e │             │ 443/tcp │ https      │ Google | gws │      │
+  ╘══════════════════════════╧═════════════╧═════════╧════════════╧══════════════╧══════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w aquatone --multi-table]
+  '''
+  http://castelblack.north.sevenkingdoms.local
+  http://winterfell.north.sevenkingdoms.local
+  https://castelblack.north.sevenkingdoms.local
+  https://winterfell.north.sevenkingdoms.local
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w aquatone]
+  '''
+  http://castelblack.north.sevenkingdoms.local
+  http://winterfell.north.sevenkingdoms.local
+  https://castelblack.north.sevenkingdoms.local
+  https://winterfell.north.sevenkingdoms.local
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w csv --multi-table]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  ,castelblack.north.sevenkingdoms.local,,,,windows
+  ,winterfell.north.sevenkingdoms.local,,,,windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w csv]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  ,castelblack.north.sevenkingdoms.local,,,,windows
+  ,winterfell.north.sevenkingdoms.local,,,,windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w host --multi-table]
+  '''
+  castelblack.north.sevenkingdoms.local
+  winterfell.north.sevenkingdoms.local
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w host]
+  '''
+  castelblack.north.sevenkingdoms.local
+  winterfell.north.sevenkingdoms.local
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w html --multi-table]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th></th>
+        <th>castelblack.north.sevenkingdoms.local</th>
+        <th>windows</th>
+      </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th></th>
+        <th>winterfell.north.sevenkingdoms.local</th>
+        <th>windows</th>
+      </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w html]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>IP-Addresses</th>
+        <th>Hostnames</th>
+        <th>Ports</th>
+        <th>Services</th>
+        <th>Banners</th>
+        <th>OS</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td></td>
+        <td>castelblack.north.sevenkingdoms.local</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td>windows</td>
+      </tr>
+      <tr>
+        <td></td>
+        <td>winterfell.north.sevenkingdoms.local</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td>windows</td>
+      </tr>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w json --multi-table]
+  '''
+  {"unknown_0":{"hostnames":["castelblack.north.sevenkingdoms.local"],"tcp_ports":{},"udp_ports":{},"os":["windows"]},"unknown_1":{"hostnames":["winterfell.north.sevenkingdoms.local"],"tcp_ports":{},"udp_ports":{},"os":["windows"]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w json]
+  '''
+  {"unknown_0":{"hostnames":["castelblack.north.sevenkingdoms.local"],"tcp_ports":{},"udp_ports":{},"os":["windows"]},"unknown_1":{"hostnames":["winterfell.north.sevenkingdoms.local"],"tcp_ports":{},"udp_ports":{},"os":["windows"]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w latex --multi-table]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{rrr}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{} & \makecell[l]{castelblack.north.sevenkingdoms.local} & \makecell[l]{windows} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{} & \makecell[l]{castelblack.north.sevenkingdoms.local} & \makecell[l]{windows} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{0}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \end{longtable}
+  
+  
+  \begin{longtable}{rrr}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{} & \makecell[l]{winterfell.north.sevenkingdoms.local} & \makecell[l]{windows} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{} & \makecell[l]{winterfell.north.sevenkingdoms.local} & \makecell[l]{windows} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{0}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w latex]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{llllll}
+  \caption{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{6}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{} & \makecell[l]{castelblack.north.sevenkingdoms.local} & \makecell[l]{} & \makecell[l]{} & \makecell[l]{} & \makecell[l]{windows} \\
+  \makecell[l]{} & \makecell[l]{winterfell.north.sevenkingdoms.local} & \makecell[l]{} & \makecell[l]{} & \makecell[l]{} & \makecell[l]{windows} \\
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w markdown --multi-table]
+  '''
+  |    | castelblack.north.sevenkingdoms.local   | windows   |
+  |----|-----------------------------------------|-----------|
+  
+  
+  |    | winterfell.north.sevenkingdoms.local   | windows   |
+  |----|----------------------------------------|-----------|
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w markdown]
+  '''
+  | IP-Addresses   | Hostnames                             | Ports   | Services   | Banners   | OS      |
+  |:---------------|:--------------------------------------|:--------|:-----------|:----------|:--------|
+  |                | castelblack.north.sevenkingdoms.local |         |            |           | windows |
+  |                | winterfell.north.sevenkingdoms.local  |         |            |           | windows |
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w nmap --multi-table]
+  '''
+  #!/bin/sh
+  
+  nmap castelblack.north.sevenkingdoms.local -sS -A -Pn -n -T4 -oA castelblack.north.sevenkingdoms.local --top-ports 1000
+  nmap winterfell.north.sevenkingdoms.local -sS -A -Pn -n -T4 -oA winterfell.north.sevenkingdoms.local --top-ports 1000
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w nmap]
+  '''
+  #!/bin/sh
+  
+  nmap castelblack.north.sevenkingdoms.local -sS -A -Pn -n -T4 -oA castelblack.north.sevenkingdoms.local --top-ports 1000
+  nmap winterfell.north.sevenkingdoms.local -sS -A -Pn -n -T4 -oA winterfell.north.sevenkingdoms.local --top-ports 1000
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w terminal --multi-table]
+  '''
+  ╒════╤═════════════════════════════════════════╤═══════════╕
+  │    │ castelblack.north.sevenkingdoms.local   │ windows   │
+  ╞════╪═════════════════════════════════════════╪═══════════╡
+  ╘════╧═════════════════════════════════════════╧═══════════╛
+  
+  ╒════╤════════════════════════════════════════╤═══════════╕
+  │    │ winterfell.north.sevenkingdoms.local   │ windows   │
+  ╞════╪════════════════════════════════════════╪═══════════╡
+  ╘════╧════════════════════════════════════════╧═══════════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w terminal]
+  '''
+  ╒════════════════╤═══════════════════════════════════════╤═════════╤════════════╤═══════════╤═════════╕
+  │ IP-Addresses   │ Hostnames                             │ Ports   │ Services   │ Banners   │ OS      │
+  ╞════════════════╪═══════════════════════════════════════╪═════════╪════════════╪═══════════╪═════════╡
+  │                │ castelblack.north.sevenkingdoms.local │         │            │           │ windows │
+  ├────────────────┼───────────────────────────────────────┼─────────┼────────────┼───────────┼─────────┤
+  │                │ winterfell.north.sevenkingdoms.local  │         │            │           │ windows │
+  ╘════════════════╧═══════════════════════════════════════╧═════════╧════════════╧═══════════╧═════════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w typst --multi-table]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (3),
+    [**], [*castelblack.north.sevenkingdoms.local*], [*windows*],
+    
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [**], [*winterfell.north.sevenkingdoms.local*], [*windows*],
+    
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w typst]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (6),
+    [*IP-Addresses*], [*Hostnames*], [*Ports*], [*Services*], [*Banners*], [*OS*],
+    [], [castelblack.north.sevenkingdoms.local], [], [], [], [windows],
+    [], [winterfell.north.sevenkingdoms.local], [], [], [], [windows]
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w url --multi-table]
+  '''
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w url]
+  '''
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w xml --multi-table]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="unknown_0">
+      <hostnames>
+        <hostname>castelblack.north.sevenkingdoms.local</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+    </host>
+    <host ip="unknown_1">
+      <hostnames>
+        <hostname>winterfell.north.sevenkingdoms.local</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w xml]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="unknown_0">
+      <hostnames>
+        <hostname>castelblack.north.sevenkingdoms.local</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+    </host>
+    <host ip="unknown_1">
+      <hostnames>
+        <hostname>winterfell.north.sevenkingdoms.local</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w yaml --multi-table]
+  '''
+  unknown_0:
+      hostnames:
+      - castelblack.north.sevenkingdoms.local
+      tcp_ports: {}
+      udp_ports: {}
+      os:
+      - windows
+  unknown_1:
+      hostnames:
+      - winterfell.north.sevenkingdoms.local
+      tcp_ports: {}
+      udp_ports: {}
+      os:
+      - windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--bloodhound tests/data/bloodhound/goad-light-north.sevenkingdoms_computers.json -w yaml]
+  '''
+  unknown_0:
+      hostnames:
+      - castelblack.north.sevenkingdoms.local
+      tcp_ports: {}
+      udp_ports: {}
+      os:
+      - windows
+  unknown_1:
+      hostnames:
+      - winterfell.north.sevenkingdoms.local
+      tcp_ports: {}
+      udp_ports: {}
+      os:
+      - windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/ipv6/json/infra.json -w terminal]
+  '''
+  ╒══════════════════════════╤═════════════╤═════════╤════════════╤═══════════╤══════╕
+  │ IP-Addresses             │ Hostnames   │ Ports   │ Services   │ Banners   │ OS   │
+  ╞══════════════════════════╪═════════════╪═════════╪════════════╪═══════════╪══════╡
+  │ 192.168.56.22            │ host2       │ 80/tcp  │ http       │           │      │
+  ├──────────────────────────┼─────────────┼─────────┼────────────┼───────────┼──────┤
+  │ 2a00:1450:4001:828::200e │ host1       │ 81/tcp  │ http       │           │      │
+  ╘══════════════════════════╧═════════════╧═════════╧════════════╧═══════════╧══════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w aquatone --multi-table]
+  '''
+  http://1.1.1.1:22
+  http://2.2.2.2
+  http://empty-host.example.com
+  http://host1.example.com:22
+  https://1.1.1.1:22
+  https://2.2.2.2
+  https://empty-host.example.com
+  https://host1.example.com:22
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w aquatone]
+  '''
+  http://1.1.1.1:22
+  http://2.2.2.2
+  http://empty-host.example.com
+  http://host1.example.com:22
+  https://1.1.1.1:22
+  https://2.2.2.2
+  https://empty-host.example.com
+  https://host1.example.com:22
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w csv --multi-table]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  1.1.1.1,host1.example.com,22/tcp,ssh,,
+  2.2.2.2,empty\-host.example.com,,,,
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w csv]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  1.1.1.1,host1.example.com,22/tcp,ssh,,
+  2.2.2.2,empty\-host.example.com,,,,
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w host --multi-table]
+  '''
+  1.1.1.1
+  2.2.2.2
+  empty-host.example.com
+  host1.example.com
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w host]
+  '''
+  1.1.1.1
+  2.2.2.2
+  empty-host.example.com
+  host1.example.com
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w html --multi-table]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>1.1.1.1</th>
+        <th>host1.example.com</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>22/tcp</td>
+        <td>ssh</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>2.2.2.2</th>
+        <th>empty-host.example.com</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w html]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>IP-Addresses</th>
+        <th>Hostnames</th>
+        <th>Ports</th>
+        <th>Services</th>
+        <th>Banners</th>
+        <th>OS</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1.1.1.1</td>
+        <td>host1.example.com</td>
+        <td>22/tcp</td>
+        <td>ssh</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>2.2.2.2</td>
+        <td>empty-host.example.com</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w json --multi-table]
+  '''
+  {"1.1.1.1":{"hostnames":["host1.example.com"],"tcp_ports":{"22":{"service_names":["ssh"],"banners":[""]}},"udp_ports":{},"os":[]},"2.2.2.2":{"hostnames":["empty-host.example.com"],"tcp_ports":{},"udp_ports":{},"os":[]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w json]
+  '''
+  {"1.1.1.1":{"hostnames":["host1.example.com"],"tcp_ports":{"22":{"service_names":["ssh"],"banners":[""]}},"udp_ports":{},"os":[]},"2.2.2.2":{"hostnames":["empty-host.example.com"],"tcp_ports":{},"udp_ports":{},"os":[]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w latex --multi-table]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{1.1.1.1} & \makecell[l]{host1.example.com} & \makecell[l]{} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{1.1.1.1} & \makecell[l]{host1.example.com} & \makecell[l]{} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{22/tcp} & \makecell[l]{ssh} & \makecell[l]{} \\
+  \end{longtable}
+  
+  
+  \begin{longtable}{rrr}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{2.2.2.2} & \makecell[l]{empty-host.example.com} & \makecell[l]{} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{2.2.2.2} & \makecell[l]{empty-host.example.com} & \makecell[l]{} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{0}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w latex]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{llllll}
+  \caption{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{6}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{1.1.1.1} & \makecell[l]{host1.example.com} & \makecell[l]{22/tcp} & \makecell[l]{ssh} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{2.2.2.2} & \makecell[l]{empty-host.example.com} & \makecell[l]{} & \makecell[l]{} & \makecell[l]{} & \makecell[l]{} \\
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w markdown --multi-table]
+  '''
+  | 1.1.1.1   | host1.example.com   |    |
+  |:----------|:--------------------|:---|
+  | 22/tcp    | ssh                 |    |
+  
+  
+  | 2.2.2.2   | empty-host.example.com   |    |
+  |-----------|--------------------------|----|
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w markdown]
+  '''
+  | IP-Addresses   | Hostnames              | Ports   | Services   | Banners   | OS   |
+  |:---------------|:-----------------------|:--------|:-----------|:----------|:-----|
+  | 1.1.1.1        | host1.example.com      | 22/tcp  | ssh        |           |      |
+  | 2.2.2.2        | empty-host.example.com |         |            |           |      |
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w nmap --multi-table]
+  '''
+  #!/bin/sh
+  
+  nmap 1.1.1.1 -sS -A -Pn -n -T4 -oA 1.1.1.1 -p 22,23
+  nmap 2.2.2.2 -sS -A -Pn -n -T4 -oA 2.2.2.2 --top-ports 1000
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w nmap]
+  '''
+  #!/bin/sh
+  
+  nmap 1.1.1.1 -sS -A -Pn -n -T4 -oA 1.1.1.1 -p 22,23
+  nmap 2.2.2.2 -sS -A -Pn -n -T4 -oA 2.2.2.2 --top-ports 1000
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w terminal --multi-table]
+  '''
+  ╒═══════════╤═════════════════════╤════╕
+  │ 1.1.1.1   │ host1.example.com   │    │
+  ╞═══════════╪═════════════════════╪════╡
+  │ 22/tcp    │ ssh                 │    │
+  ╘═══════════╧═════════════════════╧════╛
+  
+  ╒═══════════╤══════════════════════════╤════╕
+  │ 2.2.2.2   │ empty-host.example.com   │    │
+  ╞═══════════╪══════════════════════════╪════╡
+  ╘═══════════╧══════════════════════════╧════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w terminal]
+  '''
+  ╒════════════════╤════════════════════════╤═════════╤════════════╤═══════════╤══════╕
+  │ IP-Addresses   │ Hostnames              │ Ports   │ Services   │ Banners   │ OS   │
+  ╞════════════════╪════════════════════════╪═════════╪════════════╪═══════════╪══════╡
+  │ 1.1.1.1        │ host1.example.com      │ 22/tcp  │ ssh        │           │      │
+  ├────────────────┼────────────────────────┼─────────┼────────────┼───────────┼──────┤
+  │ 2.2.2.2        │ empty-host.example.com │         │            │           │      │
+  ╘════════════════╧════════════════════════╧═════════╧════════════╧═══════════╧══════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w typst --multi-table]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (3),
+    [*1.1.1.1*], [*host1.example.com*], [**],
+    [22/tcp], [ssh], []
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [*2.2.2.2*], [*empty-host.example.com*], [**],
+    
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w typst]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (6),
+    [*IP-Addresses*], [*Hostnames*], [*Ports*], [*Services*], [*Banners*], [*OS*],
+    [1.1.1.1], [host1.example.com], [22/tcp], [ssh], [], [],
+    [2.2.2.2], [empty-host.example.com], [], [], [], []
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w url --multi-table]
+  '''
+  ssh://1.1.1.1:22
+  ssh://host1.example.com:22
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w url]
+  '''
+  ssh://1.1.1.1:22
+  ssh://host1.example.com:22
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w xml --multi-table]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="1.1.1.1">
+      <hostnames>
+        <hostname>host1.example.com</hostname>
+      </hostnames>
+      <tcp_ports>
+        <port number="22">
+          <services>
+            <service>ssh</service>
+          </services>
+          <banners/>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="2.2.2.2">
+      <hostnames>
+        <hostname>empty-host.example.com</hostname>
+      </hostnames>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w xml]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="1.1.1.1">
+      <hostnames>
+        <hostname>host1.example.com</hostname>
+      </hostnames>
+      <tcp_ports>
+        <port number="22">
+          <services>
+            <service>ssh</service>
+          </services>
+          <banners/>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="2.2.2.2">
+      <hostnames>
+        <hostname>empty-host.example.com</hostname>
+      </hostnames>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w yaml --multi-table]
+  '''
+  1.1.1.1:
+      hostnames:
+      - host1.example.com
+      tcp_ports:
+          22:
+              service_names:
+              - ssh
+              banners:
+              - ''
+      udp_ports: {}
+      os: []
+  2.2.2.2:
+      hostnames:
+      - empty-host.example.com
+      tcp_ports: {}
+      udp_ports: {}
+      os: []
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--json tests/data/json/filter_test.json -w yaml]
+  '''
+  1.1.1.1:
+      hostnames:
+      - host1.example.com
+      tcp_ports:
+          22:
+              service_names:
+              - ssh
+              banners:
+              - ''
+      udp_ports: {}
+      os: []
+  2.2.2.2:
+      hostnames:
+      - empty-host.example.com
+      tcp_ports: {}
+      udp_ports: {}
+      os: []
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/ipv6/masscan/masscan.json -w terminal]
+  '''
+  ╒══════════════════════════╤═════════════╤═════════╤════════════╤═══════════╤══════╕
+  │ IP-Addresses             │ Hostnames   │ Ports   │ Services   │ Banners   │ OS   │
+  ╞══════════════════════════╪═════════════╪═════════╪════════════╪═══════════╪══════╡
+  │ 2a00:1450:4001:800::200e │             │ 80/tcp  │            │           │      │
+  │                          │             │ 443/tcp │            │           │      │
+  ╘══════════════════════════╧═════════════╧═════════╧════════════╧═══════════╧══════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w aquatone --multi-table]
+  '''
+  http://192.168.56.10:135
+  http://192.168.56.10:139
+  http://192.168.56.10:3268
+  http://192.168.56.10:3269
+  http://192.168.56.10:3389
+  http://192.168.56.10:389
+  http://192.168.56.10:445
+  http://192.168.56.10:464
+  http://192.168.56.10:49666
+  http://192.168.56.10:49667
+  http://192.168.56.10:49675
+  http://192.168.56.10:49676
+  http://192.168.56.10:49678
+  http://192.168.56.10:49693
+  http://192.168.56.10:53
+  http://192.168.56.10:593
+  http://192.168.56.10:5985
+  http://192.168.56.10:5986
+  http://192.168.56.10:60064
+  http://192.168.56.10:636
+  http://192.168.56.10:88
+  http://192.168.56.10:9389
+  http://192.168.56.11:135
+  http://192.168.56.11:139
+  http://192.168.56.11:3389
+  http://192.168.56.11:445
+  http://192.168.56.11:49666
+  http://192.168.56.11:49667
+  http://192.168.56.11:49674
+  http://192.168.56.11:49728
+  http://192.168.56.11:53
+  http://192.168.56.11:5985
+  http://192.168.56.11:5986
+  http://192.168.56.22:3389
+  http://192.168.56.22:5985
+  http://192.168.56.22:5986
+  https://192.168.56.10:135
+  https://192.168.56.10:139
+  https://192.168.56.10:3268
+  https://192.168.56.10:3269
+  https://192.168.56.10:3389
+  https://192.168.56.10:389
+  https://192.168.56.10:445
+  https://192.168.56.10:464
+  https://192.168.56.10:49666
+  https://192.168.56.10:49667
+  https://192.168.56.10:49675
+  https://192.168.56.10:49676
+  https://192.168.56.10:49678
+  https://192.168.56.10:49693
+  https://192.168.56.10:53
+  https://192.168.56.10:593
+  https://192.168.56.10:5985
+  https://192.168.56.10:5986
+  https://192.168.56.10:60064
+  https://192.168.56.10:636
+  https://192.168.56.10:88
+  https://192.168.56.10:9389
+  https://192.168.56.11:135
+  https://192.168.56.11:139
+  https://192.168.56.11:3389
+  https://192.168.56.11:445
+  https://192.168.56.11:49666
+  https://192.168.56.11:49667
+  https://192.168.56.11:49674
+  https://192.168.56.11:49728
+  https://192.168.56.11:53
+  https://192.168.56.11:5985
+  https://192.168.56.11:5986
+  https://192.168.56.22:3389
+  https://192.168.56.22:5985
+  https://192.168.56.22:5986
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w aquatone]
+  '''
+  http://192.168.56.10:135
+  http://192.168.56.10:139
+  http://192.168.56.10:3268
+  http://192.168.56.10:3269
+  http://192.168.56.10:3389
+  http://192.168.56.10:389
+  http://192.168.56.10:445
+  http://192.168.56.10:464
+  http://192.168.56.10:49666
+  http://192.168.56.10:49667
+  http://192.168.56.10:49675
+  http://192.168.56.10:49676
+  http://192.168.56.10:49678
+  http://192.168.56.10:49693
+  http://192.168.56.10:53
+  http://192.168.56.10:593
+  http://192.168.56.10:5985
+  http://192.168.56.10:5986
+  http://192.168.56.10:60064
+  http://192.168.56.10:636
+  http://192.168.56.10:88
+  http://192.168.56.10:9389
+  http://192.168.56.11:135
+  http://192.168.56.11:139
+  http://192.168.56.11:3389
+  http://192.168.56.11:445
+  http://192.168.56.11:49666
+  http://192.168.56.11:49667
+  http://192.168.56.11:49674
+  http://192.168.56.11:49728
+  http://192.168.56.11:53
+  http://192.168.56.11:5985
+  http://192.168.56.11:5986
+  http://192.168.56.22:3389
+  http://192.168.56.22:5985
+  http://192.168.56.22:5986
+  https://192.168.56.10:135
+  https://192.168.56.10:139
+  https://192.168.56.10:3268
+  https://192.168.56.10:3269
+  https://192.168.56.10:3389
+  https://192.168.56.10:389
+  https://192.168.56.10:445
+  https://192.168.56.10:464
+  https://192.168.56.10:49666
+  https://192.168.56.10:49667
+  https://192.168.56.10:49675
+  https://192.168.56.10:49676
+  https://192.168.56.10:49678
+  https://192.168.56.10:49693
+  https://192.168.56.10:53
+  https://192.168.56.10:593
+  https://192.168.56.10:5985
+  https://192.168.56.10:5986
+  https://192.168.56.10:60064
+  https://192.168.56.10:636
+  https://192.168.56.10:88
+  https://192.168.56.10:9389
+  https://192.168.56.11:135
+  https://192.168.56.11:139
+  https://192.168.56.11:3389
+  https://192.168.56.11:445
+  https://192.168.56.11:49666
+  https://192.168.56.11:49667
+  https://192.168.56.11:49674
+  https://192.168.56.11:49728
+  https://192.168.56.11:53
+  https://192.168.56.11:5985
+  https://192.168.56.11:5986
+  https://192.168.56.22:3389
+  https://192.168.56.22:5985
+  https://192.168.56.22:5986
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w csv --multi-table]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  192.168.56.10,,53/tcp,,,
+  192.168.56.10,,88/tcp,,,
+  192.168.56.10,,135/tcp,,,
+  192.168.56.10,,139/tcp,,,
+  192.168.56.10,,389/tcp,,,
+  192.168.56.10,,445/tcp,,,
+  192.168.56.10,,464/tcp,,,
+  192.168.56.10,,593/tcp,,,
+  192.168.56.10,,636/tcp,,,
+  192.168.56.10,,3268/tcp,,,
+  192.168.56.10,,3269/tcp,,,
+  192.168.56.10,,3389/tcp,,,
+  192.168.56.10,,5985/tcp,,,
+  192.168.56.10,,5986/tcp,,,
+  192.168.56.10,,9389/tcp,,,
+  192.168.56.10,,49666/tcp,,,
+  192.168.56.10,,49667/tcp,,,
+  192.168.56.10,,49675/tcp,,,
+  192.168.56.10,,49676/tcp,,,
+  192.168.56.10,,49678/tcp,,,
+  192.168.56.10,,49693/tcp,,,
+  192.168.56.10,,60064/tcp,,,
+  192.168.56.11,,53/tcp,,,
+  192.168.56.11,,135/tcp,,,
+  192.168.56.11,,139/tcp,,,
+  192.168.56.11,,445/tcp,,,
+  192.168.56.11,,3389/tcp,,,
+  192.168.56.11,,5985/tcp,,,
+  192.168.56.11,,5986/tcp,,,
+  192.168.56.11,,49666/tcp,,,
+  192.168.56.11,,49667/tcp,,,
+  192.168.56.11,,49674/tcp,,,
+  192.168.56.11,,49728/tcp,,,
+  192.168.56.22,,3389/tcp,,,
+  192.168.56.22,,5985/tcp,,,
+  192.168.56.22,,5986/tcp,,,
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w csv]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  192.168.56.10,,53/tcp,,,
+  192.168.56.10,,88/tcp,,,
+  192.168.56.10,,135/tcp,,,
+  192.168.56.10,,139/tcp,,,
+  192.168.56.10,,389/tcp,,,
+  192.168.56.10,,445/tcp,,,
+  192.168.56.10,,464/tcp,,,
+  192.168.56.10,,593/tcp,,,
+  192.168.56.10,,636/tcp,,,
+  192.168.56.10,,3268/tcp,,,
+  192.168.56.10,,3269/tcp,,,
+  192.168.56.10,,3389/tcp,,,
+  192.168.56.10,,5985/tcp,,,
+  192.168.56.10,,5986/tcp,,,
+  192.168.56.10,,9389/tcp,,,
+  192.168.56.10,,49666/tcp,,,
+  192.168.56.10,,49667/tcp,,,
+  192.168.56.10,,49675/tcp,,,
+  192.168.56.10,,49676/tcp,,,
+  192.168.56.10,,49678/tcp,,,
+  192.168.56.10,,49693/tcp,,,
+  192.168.56.10,,60064/tcp,,,
+  192.168.56.11,,53/tcp,,,
+  192.168.56.11,,135/tcp,,,
+  192.168.56.11,,139/tcp,,,
+  192.168.56.11,,445/tcp,,,
+  192.168.56.11,,3389/tcp,,,
+  192.168.56.11,,5985/tcp,,,
+  192.168.56.11,,5986/tcp,,,
+  192.168.56.11,,49666/tcp,,,
+  192.168.56.11,,49667/tcp,,,
+  192.168.56.11,,49674/tcp,,,
+  192.168.56.11,,49728/tcp,,,
+  192.168.56.22,,3389/tcp,,,
+  192.168.56.22,,5985/tcp,,,
+  192.168.56.22,,5986/tcp,,,
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w host --multi-table]
+  '''
+  192.168.56.10
+  192.168.56.11
+  192.168.56.22
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w host]
+  '''
+  192.168.56.10
+  192.168.56.11
+  192.168.56.22
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w html --multi-table]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.10</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>53/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>88/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>135/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>139/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>389/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>445/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>464/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>593/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>636/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>3268/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>3269/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>3389/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>5985/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>5986/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>9389/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49666/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49667/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49675/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49676/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49678/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49693/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>60064/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.11</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>53/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>135/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>139/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>445/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>3389/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>5985/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>5986/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49666/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49667/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49674/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49728/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.22</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>3389/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>5985/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>5986/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w html]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>IP-Addresses</th>
+        <th>Hostnames</th>
+        <th>Ports</th>
+        <th>Services</th>
+        <th>Banners</th>
+        <th>OS</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>192.168.56.10</td>
+        <td></td>
+        <td>53/tcp<br>88/tcp<br>135/tcp<br>139/tcp<br>389/tcp<br>445/tcp<br>464/tcp<br>593/tcp<br>636/tcp<br>3268/tcp<br>3269/tcp<br>3389/tcp<br>5985/tcp<br>5986/tcp<br>9389/tcp<br>49666/tcp<br>49667/tcp<br>49675/tcp<br>49676/tcp<br>49678/tcp<br>49693/tcp<br>60064/tcp</td>
+        <td><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br></td>
+        <td><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>192.168.56.11</td>
+        <td></td>
+        <td>53/tcp<br>135/tcp<br>139/tcp<br>445/tcp<br>3389/tcp<br>5985/tcp<br>5986/tcp<br>49666/tcp<br>49667/tcp<br>49674/tcp<br>49728/tcp</td>
+        <td><br><br><br><br><br><br><br><br><br><br></td>
+        <td><br><br><br><br><br><br><br><br><br><br></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>192.168.56.22</td>
+        <td></td>
+        <td>3389/tcp<br>5985/tcp<br>5986/tcp</td>
+        <td><br><br></td>
+        <td><br><br></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w json --multi-table]
+  '''
+  {"192.168.56.10":{"hostnames":[],"tcp_ports":{"53":{"service_names":[],"banners":[""]},"88":{"service_names":[],"banners":[""]},"135":{"service_names":[],"banners":[""]},"139":{"service_names":[],"banners":[""]},"389":{"service_names":[],"banners":[""]},"445":{"service_names":[],"banners":[""]},"464":{"service_names":[],"banners":[""]},"593":{"service_names":[],"banners":[""]},"636":{"service_names":[],"banners":[""]},"3268":{"service_names":[],"banners":[""]},"3269":{"service_names":[],"banners":[""]},"3389":{"service_names":[],"banners":[""]},"5985":{"service_names":[],"banners":[""]},"5986":{"service_names":[],"banners":[""]},"9389":{"service_names":[],"banners":[""]},"49666":{"service_names":[],"banners":[""]},"49667":{"service_names":[],"banners":[""]},"49675":{"service_names":[],"banners":[""]},"49676":{"service_names":[],"banners":[""]},"49678":{"service_names":[],"banners":[""]},"49693":{"service_names":[],"banners":[""]},"60064":{"service_names":[],"banners":[""]}},"udp_ports":{},"os":[]},"192.168.56.11":{"hostnames":[],"tcp_ports":{"53":{"service_names":[],"banners":[""]},"135":{"service_names":[],"banners":[""]},"139":{"service_names":[],"banners":[""]},"445":{"service_names":[],"banners":[""]},"3389":{"service_names":[],"banners":[""]},"5985":{"service_names":[],"banners":[""]},"5986":{"service_names":[],"banners":[""]},"49666":{"service_names":[],"banners":[""]},"49667":{"service_names":[],"banners":[""]},"49674":{"service_names":[],"banners":[""]},"49728":{"service_names":[],"banners":[""]}},"udp_ports":{},"os":[]},"192.168.56.22":{"hostnames":[],"tcp_ports":{"3389":{"service_names":[],"banners":[""]},"5985":{"service_names":[],"banners":[""]},"5986":{"service_names":[],"banners":[""]}},"udp_ports":{},"os":[]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w json]
+  '''
+  {"192.168.56.10":{"hostnames":[],"tcp_ports":{"53":{"service_names":[],"banners":[""]},"88":{"service_names":[],"banners":[""]},"135":{"service_names":[],"banners":[""]},"139":{"service_names":[],"banners":[""]},"389":{"service_names":[],"banners":[""]},"445":{"service_names":[],"banners":[""]},"464":{"service_names":[],"banners":[""]},"593":{"service_names":[],"banners":[""]},"636":{"service_names":[],"banners":[""]},"3268":{"service_names":[],"banners":[""]},"3269":{"service_names":[],"banners":[""]},"3389":{"service_names":[],"banners":[""]},"5985":{"service_names":[],"banners":[""]},"5986":{"service_names":[],"banners":[""]},"9389":{"service_names":[],"banners":[""]},"49666":{"service_names":[],"banners":[""]},"49667":{"service_names":[],"banners":[""]},"49675":{"service_names":[],"banners":[""]},"49676":{"service_names":[],"banners":[""]},"49678":{"service_names":[],"banners":[""]},"49693":{"service_names":[],"banners":[""]},"60064":{"service_names":[],"banners":[""]}},"udp_ports":{},"os":[]},"192.168.56.11":{"hostnames":[],"tcp_ports":{"53":{"service_names":[],"banners":[""]},"135":{"service_names":[],"banners":[""]},"139":{"service_names":[],"banners":[""]},"445":{"service_names":[],"banners":[""]},"3389":{"service_names":[],"banners":[""]},"5985":{"service_names":[],"banners":[""]},"5986":{"service_names":[],"banners":[""]},"49666":{"service_names":[],"banners":[""]},"49667":{"service_names":[],"banners":[""]},"49674":{"service_names":[],"banners":[""]},"49728":{"service_names":[],"banners":[""]}},"udp_ports":{},"os":[]},"192.168.56.22":{"hostnames":[],"tcp_ports":{"3389":{"service_names":[],"banners":[""]},"5985":{"service_names":[],"banners":[""]},"5986":{"service_names":[],"banners":[""]}},"udp_ports":{},"os":[]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w latex --multi-table]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.10} & \makecell[l]{} & \makecell[l]{} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.10} & \makecell[l]{} & \makecell[l]{} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{53/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{88/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{135/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{139/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{389/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{445/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{464/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{593/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{636/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{3268/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{3269/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{3389/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{5985/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{5986/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{9389/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{49666/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{49667/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{49675/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{49676/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{49678/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{49693/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{60064/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \end{longtable}
+  
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.11} & \makecell[l]{} & \makecell[l]{} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.11} & \makecell[l]{} & \makecell[l]{} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{53/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{135/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{139/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{445/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{3389/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{5985/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{5986/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{49666/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{49667/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{49674/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{49728/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \end{longtable}
+  
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.22} & \makecell[l]{} & \makecell[l]{} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.22} & \makecell[l]{} & \makecell[l]{} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{3389/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{5985/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{5986/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w latex]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{llllll}
+  \caption{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{6}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{192.168.56.10} & \makecell[l]{} & \makecell[l]{53/tcp \\ 88/tcp \\ 135/tcp \\ 139/tcp \\ 389/tcp \\ 445/tcp \\ 464/tcp \\ 593/tcp \\ 636/tcp \\ 3268/tcp \\ 3269/tcp \\ 3389/tcp \\ 5985/tcp \\ 5986/tcp \\ 9389/tcp \\ 49666/tcp \\ 49667/tcp \\ 49675/tcp \\ 49676/tcp \\ 49678/tcp \\ 49693/tcp \\ 60064/tcp} & \makecell[l]{ \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\ } & \makecell[l]{ \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\ } & \makecell[l]{} \\
+  \makecell[l]{192.168.56.11} & \makecell[l]{} & \makecell[l]{53/tcp \\ 135/tcp \\ 139/tcp \\ 445/tcp \\ 3389/tcp \\ 5985/tcp \\ 5986/tcp \\ 49666/tcp \\ 49667/tcp \\ 49674/tcp \\ 49728/tcp} & \makecell[l]{ \\  \\  \\  \\  \\  \\  \\  \\  \\  \\ } & \makecell[l]{ \\  \\  \\  \\  \\  \\  \\  \\  \\  \\ } & \makecell[l]{} \\
+  \makecell[l]{192.168.56.22} & \makecell[l]{} & \makecell[l]{3389/tcp \\ 5985/tcp \\ 5986/tcp} & \makecell[l]{ \\  \\ } & \makecell[l]{ \\  \\ } & \makecell[l]{} \\
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w markdown --multi-table]
+  '''
+  | 192.168.56.10   |    |    |
+  |:----------------|:---|:---|
+  | 53/tcp          |    |    |
+  | 88/tcp          |    |    |
+  | 135/tcp         |    |    |
+  | 139/tcp         |    |    |
+  | 389/tcp         |    |    |
+  | 445/tcp         |    |    |
+  | 464/tcp         |    |    |
+  | 593/tcp         |    |    |
+  | 636/tcp         |    |    |
+  | 3268/tcp        |    |    |
+  | 3269/tcp        |    |    |
+  | 3389/tcp        |    |    |
+  | 5985/tcp        |    |    |
+  | 5986/tcp        |    |    |
+  | 9389/tcp        |    |    |
+  | 49666/tcp       |    |    |
+  | 49667/tcp       |    |    |
+  | 49675/tcp       |    |    |
+  | 49676/tcp       |    |    |
+  | 49678/tcp       |    |    |
+  | 49693/tcp       |    |    |
+  | 60064/tcp       |    |    |
+  
+  
+  | 192.168.56.11   |    |    |
+  |:----------------|:---|:---|
+  | 53/tcp          |    |    |
+  | 135/tcp         |    |    |
+  | 139/tcp         |    |    |
+  | 445/tcp         |    |    |
+  | 3389/tcp        |    |    |
+  | 5985/tcp        |    |    |
+  | 5986/tcp        |    |    |
+  | 49666/tcp       |    |    |
+  | 49667/tcp       |    |    |
+  | 49674/tcp       |    |    |
+  | 49728/tcp       |    |    |
+  
+  
+  | 192.168.56.22   |    |    |
+  |:----------------|:---|:---|
+  | 3389/tcp        |    |    |
+  | 5985/tcp        |    |    |
+  | 5986/tcp        |    |    |
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w markdown]
+  '''
+  | IP-Addresses   | Hostnames   | Ports                                                                                                                                                                                                                                                            | Services                                                                             | Banners                                                                              | OS   |
+  |:---------------|:------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------|:-----|
+  | 192.168.56.10  |             | 53/tcp<br>88/tcp<br>135/tcp<br>139/tcp<br>389/tcp<br>445/tcp<br>464/tcp<br>593/tcp<br>636/tcp<br>3268/tcp<br>3269/tcp<br>3389/tcp<br>5985/tcp<br>5986/tcp<br>9389/tcp<br>49666/tcp<br>49667/tcp<br>49675/tcp<br>49676/tcp<br>49678/tcp<br>49693/tcp<br>60064/tcp | <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br> | <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br> |      |
+  | 192.168.56.11  |             | 53/tcp<br>135/tcp<br>139/tcp<br>445/tcp<br>3389/tcp<br>5985/tcp<br>5986/tcp<br>49666/tcp<br>49667/tcp<br>49674/tcp<br>49728/tcp                                                                                                                                  | <br><br><br><br><br><br><br><br><br><br>                                             | <br><br><br><br><br><br><br><br><br><br>                                             |      |
+  | 192.168.56.22  |             | 3389/tcp<br>5985/tcp<br>5986/tcp                                                                                                                                                                                                                                 | <br><br>                                                                             | <br><br>                                                                             |      |
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w nmap --multi-table]
+  '''
+  #!/bin/sh
+  
+  nmap 192.168.56.10 -sS -A -Pn -n -T4 -oA 192.168.56.10 -p 53,88,135,139,389,445,464,593,636,3268,3269,3389,5985,5986,9389,49666,49667,49675,49676,49678,49693,60064,60065
+  nmap 192.168.56.11 -sS -A -Pn -n -T4 -oA 192.168.56.11 -p 53,135,139,445,3389,5985,5986,49666,49667,49674,49728,49729
+  nmap 192.168.56.22 -sS -A -Pn -n -T4 -oA 192.168.56.22 -p 3389,5985,5986,5987
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w nmap]
+  '''
+  #!/bin/sh
+  
+  nmap 192.168.56.10 -sS -A -Pn -n -T4 -oA 192.168.56.10 -p 53,88,135,139,389,445,464,593,636,3268,3269,3389,5985,5986,9389,49666,49667,49675,49676,49678,49693,60064,60065
+  nmap 192.168.56.11 -sS -A -Pn -n -T4 -oA 192.168.56.11 -p 53,135,139,445,3389,5985,5986,49666,49667,49674,49728,49729
+  nmap 192.168.56.22 -sS -A -Pn -n -T4 -oA 192.168.56.22 -p 3389,5985,5986,5987
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w terminal --multi-table]
+  '''
+  ╒═════════════════╤════╤════╕
+  │ 192.168.56.10   │    │    │
+  ╞═════════════════╪════╪════╡
+  │ 53/tcp          │    │    │
+  ├─────────────────┼────┼────┤
+  │ 88/tcp          │    │    │
+  ├─────────────────┼────┼────┤
+  │ 135/tcp         │    │    │
+  ├─────────────────┼────┼────┤
+  │ 139/tcp         │    │    │
+  ├─────────────────┼────┼────┤
+  │ 389/tcp         │    │    │
+  ├─────────────────┼────┼────┤
+  │ 445/tcp         │    │    │
+  ├─────────────────┼────┼────┤
+  │ 464/tcp         │    │    │
+  ├─────────────────┼────┼────┤
+  │ 593/tcp         │    │    │
+  ├─────────────────┼────┼────┤
+  │ 636/tcp         │    │    │
+  ├─────────────────┼────┼────┤
+  │ 3268/tcp        │    │    │
+  ├─────────────────┼────┼────┤
+  │ 3269/tcp        │    │    │
+  ├─────────────────┼────┼────┤
+  │ 3389/tcp        │    │    │
+  ├─────────────────┼────┼────┤
+  │ 5985/tcp        │    │    │
+  ├─────────────────┼────┼────┤
+  │ 5986/tcp        │    │    │
+  ├─────────────────┼────┼────┤
+  │ 9389/tcp        │    │    │
+  ├─────────────────┼────┼────┤
+  │ 49666/tcp       │    │    │
+  ├─────────────────┼────┼────┤
+  │ 49667/tcp       │    │    │
+  ├─────────────────┼────┼────┤
+  │ 49675/tcp       │    │    │
+  ├─────────────────┼────┼────┤
+  │ 49676/tcp       │    │    │
+  ├─────────────────┼────┼────┤
+  │ 49678/tcp       │    │    │
+  ├─────────────────┼────┼────┤
+  │ 49693/tcp       │    │    │
+  ├─────────────────┼────┼────┤
+  │ 60064/tcp       │    │    │
+  ╘═════════════════╧════╧════╛
+  
+  ╒═════════════════╤════╤════╕
+  │ 192.168.56.11   │    │    │
+  ╞═════════════════╪════╪════╡
+  │ 53/tcp          │    │    │
+  ├─────────────────┼────┼────┤
+  │ 135/tcp         │    │    │
+  ├─────────────────┼────┼────┤
+  │ 139/tcp         │    │    │
+  ├─────────────────┼────┼────┤
+  │ 445/tcp         │    │    │
+  ├─────────────────┼────┼────┤
+  │ 3389/tcp        │    │    │
+  ├─────────────────┼────┼────┤
+  │ 5985/tcp        │    │    │
+  ├─────────────────┼────┼────┤
+  │ 5986/tcp        │    │    │
+  ├─────────────────┼────┼────┤
+  │ 49666/tcp       │    │    │
+  ├─────────────────┼────┼────┤
+  │ 49667/tcp       │    │    │
+  ├─────────────────┼────┼────┤
+  │ 49674/tcp       │    │    │
+  ├─────────────────┼────┼────┤
+  │ 49728/tcp       │    │    │
+  ╘═════════════════╧════╧════╛
+  
+  ╒═════════════════╤════╤════╕
+  │ 192.168.56.22   │    │    │
+  ╞═════════════════╪════╪════╡
+  │ 3389/tcp        │    │    │
+  ├─────────────────┼────┼────┤
+  │ 5985/tcp        │    │    │
+  ├─────────────────┼────┼────┤
+  │ 5986/tcp        │    │    │
+  ╘═════════════════╧════╧════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w terminal]
+  '''
+  ╒════════════════╤═════════════╤═══════════╤════════════╤═══════════╤══════╕
+  │ IP-Addresses   │ Hostnames   │ Ports     │ Services   │ Banners   │ OS   │
+  ╞════════════════╪═════════════╪═══════════╪════════════╪═══════════╪══════╡
+  │ 192.168.56.10  │             │ 53/tcp    │            │           │      │
+  │                │             │ 88/tcp    │            │           │      │
+  │                │             │ 135/tcp   │            │           │      │
+  │                │             │ 139/tcp   │            │           │      │
+  │                │             │ 389/tcp   │            │           │      │
+  │                │             │ 445/tcp   │            │           │      │
+  │                │             │ 464/tcp   │            │           │      │
+  │                │             │ 593/tcp   │            │           │      │
+  │                │             │ 636/tcp   │            │           │      │
+  │                │             │ 3268/tcp  │            │           │      │
+  │                │             │ 3269/tcp  │            │           │      │
+  │                │             │ 3389/tcp  │            │           │      │
+  │                │             │ 5985/tcp  │            │           │      │
+  │                │             │ 5986/tcp  │            │           │      │
+  │                │             │ 9389/tcp  │            │           │      │
+  │                │             │ 49666/tcp │            │           │      │
+  │                │             │ 49667/tcp │            │           │      │
+  │                │             │ 49675/tcp │            │           │      │
+  │                │             │ 49676/tcp │            │           │      │
+  │                │             │ 49678/tcp │            │           │      │
+  │                │             │ 49693/tcp │            │           │      │
+  │                │             │ 60064/tcp │            │           │      │
+  ├────────────────┼─────────────┼───────────┼────────────┼───────────┼──────┤
+  │ 192.168.56.11  │             │ 53/tcp    │            │           │      │
+  │                │             │ 135/tcp   │            │           │      │
+  │                │             │ 139/tcp   │            │           │      │
+  │                │             │ 445/tcp   │            │           │      │
+  │                │             │ 3389/tcp  │            │           │      │
+  │                │             │ 5985/tcp  │            │           │      │
+  │                │             │ 5986/tcp  │            │           │      │
+  │                │             │ 49666/tcp │            │           │      │
+  │                │             │ 49667/tcp │            │           │      │
+  │                │             │ 49674/tcp │            │           │      │
+  │                │             │ 49728/tcp │            │           │      │
+  ├────────────────┼─────────────┼───────────┼────────────┼───────────┼──────┤
+  │ 192.168.56.22  │             │ 3389/tcp  │            │           │      │
+  │                │             │ 5985/tcp  │            │           │      │
+  │                │             │ 5986/tcp  │            │           │      │
+  ╘════════════════╧═════════════╧═══════════╧════════════╧═══════════╧══════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w typst --multi-table]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (3),
+    [*192.168.56.10*], [**], [**],
+    [53/tcp], [], [],
+    [88/tcp], [], [],
+    [135/tcp], [], [],
+    [139/tcp], [], [],
+    [389/tcp], [], [],
+    [445/tcp], [], [],
+    [464/tcp], [], [],
+    [593/tcp], [], [],
+    [636/tcp], [], [],
+    [3268/tcp], [], [],
+    [3269/tcp], [], [],
+    [3389/tcp], [], [],
+    [5985/tcp], [], [],
+    [5986/tcp], [], [],
+    [9389/tcp], [], [],
+    [49666/tcp], [], [],
+    [49667/tcp], [], [],
+    [49675/tcp], [], [],
+    [49676/tcp], [], [],
+    [49678/tcp], [], [],
+    [49693/tcp], [], [],
+    [60064/tcp], [], []
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [*192.168.56.11*], [**], [**],
+    [53/tcp], [], [],
+    [135/tcp], [], [],
+    [139/tcp], [], [],
+    [445/tcp], [], [],
+    [3389/tcp], [], [],
+    [5985/tcp], [], [],
+    [5986/tcp], [], [],
+    [49666/tcp], [], [],
+    [49667/tcp], [], [],
+    [49674/tcp], [], [],
+    [49728/tcp], [], []
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [*192.168.56.22*], [**], [**],
+    [3389/tcp], [], [],
+    [5985/tcp], [], [],
+    [5986/tcp], [], []
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w typst]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (6),
+    [*IP-Addresses*], [*Hostnames*], [*Ports*], [*Services*], [*Banners*], [*OS*],
+    [192.168.56.10], [], [53/tcp \ 88/tcp \ 135/tcp \ 139/tcp \ 389/tcp \ 445/tcp \ 464/tcp \ 593/tcp \ 636/tcp \ 3268/tcp \ 3269/tcp \ 3389/tcp \ 5985/tcp \ 5986/tcp \ 9389/tcp \ 49666/tcp \ 49667/tcp \ 49675/tcp \ 49676/tcp \ 49678/tcp \ 49693/tcp \ 60064/tcp], [ \  \  \  \  \  \  \  \  \  \  \  \  \  \  \  \  \  \  \  \  \ ], [ \  \  \  \  \  \  \  \  \  \  \  \  \  \  \  \  \  \  \  \  \ ], [],
+    [192.168.56.11], [], [53/tcp \ 135/tcp \ 139/tcp \ 445/tcp \ 3389/tcp \ 5985/tcp \ 5986/tcp \ 49666/tcp \ 49667/tcp \ 49674/tcp \ 49728/tcp], [ \  \  \  \  \  \  \  \  \  \ ], [ \  \  \  \  \  \  \  \  \  \ ], [],
+    [192.168.56.22], [], [3389/tcp \ 5985/tcp \ 5986/tcp], [ \  \ ], [ \  \ ], []
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w url --multi-table]
+  '''
+  unknown://192.168.56.10:135
+  unknown://192.168.56.10:139
+  unknown://192.168.56.10:3268
+  unknown://192.168.56.10:3269
+  unknown://192.168.56.10:3389
+  unknown://192.168.56.10:389
+  unknown://192.168.56.10:445
+  unknown://192.168.56.10:464
+  unknown://192.168.56.10:49666
+  unknown://192.168.56.10:49667
+  unknown://192.168.56.10:49675
+  unknown://192.168.56.10:49676
+  unknown://192.168.56.10:49678
+  unknown://192.168.56.10:49693
+  unknown://192.168.56.10:53
+  unknown://192.168.56.10:593
+  unknown://192.168.56.10:5985
+  unknown://192.168.56.10:5986
+  unknown://192.168.56.10:60064
+  unknown://192.168.56.10:636
+  unknown://192.168.56.10:88
+  unknown://192.168.56.10:9389
+  unknown://192.168.56.11:135
+  unknown://192.168.56.11:139
+  unknown://192.168.56.11:3389
+  unknown://192.168.56.11:445
+  unknown://192.168.56.11:49666
+  unknown://192.168.56.11:49667
+  unknown://192.168.56.11:49674
+  unknown://192.168.56.11:49728
+  unknown://192.168.56.11:53
+  unknown://192.168.56.11:5985
+  unknown://192.168.56.11:5986
+  unknown://192.168.56.22:3389
+  unknown://192.168.56.22:5985
+  unknown://192.168.56.22:5986
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w url]
+  '''
+  unknown://192.168.56.10:135
+  unknown://192.168.56.10:139
+  unknown://192.168.56.10:3268
+  unknown://192.168.56.10:3269
+  unknown://192.168.56.10:3389
+  unknown://192.168.56.10:389
+  unknown://192.168.56.10:445
+  unknown://192.168.56.10:464
+  unknown://192.168.56.10:49666
+  unknown://192.168.56.10:49667
+  unknown://192.168.56.10:49675
+  unknown://192.168.56.10:49676
+  unknown://192.168.56.10:49678
+  unknown://192.168.56.10:49693
+  unknown://192.168.56.10:53
+  unknown://192.168.56.10:593
+  unknown://192.168.56.10:5985
+  unknown://192.168.56.10:5986
+  unknown://192.168.56.10:60064
+  unknown://192.168.56.10:636
+  unknown://192.168.56.10:88
+  unknown://192.168.56.10:9389
+  unknown://192.168.56.11:135
+  unknown://192.168.56.11:139
+  unknown://192.168.56.11:3389
+  unknown://192.168.56.11:445
+  unknown://192.168.56.11:49666
+  unknown://192.168.56.11:49667
+  unknown://192.168.56.11:49674
+  unknown://192.168.56.11:49728
+  unknown://192.168.56.11:53
+  unknown://192.168.56.11:5985
+  unknown://192.168.56.11:5986
+  unknown://192.168.56.22:3389
+  unknown://192.168.56.22:5985
+  unknown://192.168.56.22:5986
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w xml --multi-table]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="192.168.56.10">
+      <tcp_ports>
+        <port number="53">
+          <banners/>
+        </port>
+        <port number="88">
+          <banners/>
+        </port>
+        <port number="135">
+          <banners/>
+        </port>
+        <port number="139">
+          <banners/>
+        </port>
+        <port number="389">
+          <banners/>
+        </port>
+        <port number="445">
+          <banners/>
+        </port>
+        <port number="464">
+          <banners/>
+        </port>
+        <port number="593">
+          <banners/>
+        </port>
+        <port number="636">
+          <banners/>
+        </port>
+        <port number="3268">
+          <banners/>
+        </port>
+        <port number="3269">
+          <banners/>
+        </port>
+        <port number="3389">
+          <banners/>
+        </port>
+        <port number="5985">
+          <banners/>
+        </port>
+        <port number="5986">
+          <banners/>
+        </port>
+        <port number="9389">
+          <banners/>
+        </port>
+        <port number="49666">
+          <banners/>
+        </port>
+        <port number="49667">
+          <banners/>
+        </port>
+        <port number="49675">
+          <banners/>
+        </port>
+        <port number="49676">
+          <banners/>
+        </port>
+        <port number="49678">
+          <banners/>
+        </port>
+        <port number="49693">
+          <banners/>
+        </port>
+        <port number="60064">
+          <banners/>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.11">
+      <tcp_ports>
+        <port number="53">
+          <banners/>
+        </port>
+        <port number="135">
+          <banners/>
+        </port>
+        <port number="139">
+          <banners/>
+        </port>
+        <port number="445">
+          <banners/>
+        </port>
+        <port number="3389">
+          <banners/>
+        </port>
+        <port number="5985">
+          <banners/>
+        </port>
+        <port number="5986">
+          <banners/>
+        </port>
+        <port number="49666">
+          <banners/>
+        </port>
+        <port number="49667">
+          <banners/>
+        </port>
+        <port number="49674">
+          <banners/>
+        </port>
+        <port number="49728">
+          <banners/>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.22">
+      <tcp_ports>
+        <port number="3389">
+          <banners/>
+        </port>
+        <port number="5985">
+          <banners/>
+        </port>
+        <port number="5986">
+          <banners/>
+        </port>
+      </tcp_ports>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w xml]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="192.168.56.10">
+      <tcp_ports>
+        <port number="53">
+          <banners/>
+        </port>
+        <port number="88">
+          <banners/>
+        </port>
+        <port number="135">
+          <banners/>
+        </port>
+        <port number="139">
+          <banners/>
+        </port>
+        <port number="389">
+          <banners/>
+        </port>
+        <port number="445">
+          <banners/>
+        </port>
+        <port number="464">
+          <banners/>
+        </port>
+        <port number="593">
+          <banners/>
+        </port>
+        <port number="636">
+          <banners/>
+        </port>
+        <port number="3268">
+          <banners/>
+        </port>
+        <port number="3269">
+          <banners/>
+        </port>
+        <port number="3389">
+          <banners/>
+        </port>
+        <port number="5985">
+          <banners/>
+        </port>
+        <port number="5986">
+          <banners/>
+        </port>
+        <port number="9389">
+          <banners/>
+        </port>
+        <port number="49666">
+          <banners/>
+        </port>
+        <port number="49667">
+          <banners/>
+        </port>
+        <port number="49675">
+          <banners/>
+        </port>
+        <port number="49676">
+          <banners/>
+        </port>
+        <port number="49678">
+          <banners/>
+        </port>
+        <port number="49693">
+          <banners/>
+        </port>
+        <port number="60064">
+          <banners/>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.11">
+      <tcp_ports>
+        <port number="53">
+          <banners/>
+        </port>
+        <port number="135">
+          <banners/>
+        </port>
+        <port number="139">
+          <banners/>
+        </port>
+        <port number="445">
+          <banners/>
+        </port>
+        <port number="3389">
+          <banners/>
+        </port>
+        <port number="5985">
+          <banners/>
+        </port>
+        <port number="5986">
+          <banners/>
+        </port>
+        <port number="49666">
+          <banners/>
+        </port>
+        <port number="49667">
+          <banners/>
+        </port>
+        <port number="49674">
+          <banners/>
+        </port>
+        <port number="49728">
+          <banners/>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.22">
+      <tcp_ports>
+        <port number="3389">
+          <banners/>
+        </port>
+        <port number="5985">
+          <banners/>
+        </port>
+        <port number="5986">
+          <banners/>
+        </port>
+      </tcp_ports>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w yaml --multi-table]
+  '''
+  192.168.56.10:
+      hostnames: []
+      tcp_ports:
+          53:
+              service_names: []
+              banners:
+              - ''
+          88:
+              service_names: []
+              banners:
+              - ''
+          135:
+              service_names: []
+              banners:
+              - ''
+          139:
+              service_names: []
+              banners:
+              - ''
+          389:
+              service_names: []
+              banners:
+              - ''
+          445:
+              service_names: []
+              banners:
+              - ''
+          464:
+              service_names: []
+              banners:
+              - ''
+          593:
+              service_names: []
+              banners:
+              - ''
+          636:
+              service_names: []
+              banners:
+              - ''
+          3268:
+              service_names: []
+              banners:
+              - ''
+          3269:
+              service_names: []
+              banners:
+              - ''
+          3389:
+              service_names: []
+              banners:
+              - ''
+          5985:
+              service_names: []
+              banners:
+              - ''
+          5986:
+              service_names: []
+              banners:
+              - ''
+          9389:
+              service_names: []
+              banners:
+              - ''
+          49666:
+              service_names: []
+              banners:
+              - ''
+          49667:
+              service_names: []
+              banners:
+              - ''
+          49675:
+              service_names: []
+              banners:
+              - ''
+          49676:
+              service_names: []
+              banners:
+              - ''
+          49678:
+              service_names: []
+              banners:
+              - ''
+          49693:
+              service_names: []
+              banners:
+              - ''
+          60064:
+              service_names: []
+              banners:
+              - ''
+      udp_ports: {}
+      os: []
+  192.168.56.11:
+      hostnames: []
+      tcp_ports:
+          53:
+              service_names: []
+              banners:
+              - ''
+          135:
+              service_names: []
+              banners:
+              - ''
+          139:
+              service_names: []
+              banners:
+              - ''
+          445:
+              service_names: []
+              banners:
+              - ''
+          3389:
+              service_names: []
+              banners:
+              - ''
+          5985:
+              service_names: []
+              banners:
+              - ''
+          5986:
+              service_names: []
+              banners:
+              - ''
+          49666:
+              service_names: []
+              banners:
+              - ''
+          49667:
+              service_names: []
+              banners:
+              - ''
+          49674:
+              service_names: []
+              banners:
+              - ''
+          49728:
+              service_names: []
+              banners:
+              - ''
+      udp_ports: {}
+      os: []
+  192.168.56.22:
+      hostnames: []
+      tcp_ports:
+          3389:
+              service_names: []
+              banners:
+              - ''
+          5985:
+              service_names: []
+              banners:
+              - ''
+          5986:
+              service_names: []
+              banners:
+              - ''
+      udp_ports: {}
+      os: []
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--masscan tests/data/masscan/goad-light.json -w yaml]
+  '''
+  192.168.56.10:
+      hostnames: []
+      tcp_ports:
+          53:
+              service_names: []
+              banners:
+              - ''
+          88:
+              service_names: []
+              banners:
+              - ''
+          135:
+              service_names: []
+              banners:
+              - ''
+          139:
+              service_names: []
+              banners:
+              - ''
+          389:
+              service_names: []
+              banners:
+              - ''
+          445:
+              service_names: []
+              banners:
+              - ''
+          464:
+              service_names: []
+              banners:
+              - ''
+          593:
+              service_names: []
+              banners:
+              - ''
+          636:
+              service_names: []
+              banners:
+              - ''
+          3268:
+              service_names: []
+              banners:
+              - ''
+          3269:
+              service_names: []
+              banners:
+              - ''
+          3389:
+              service_names: []
+              banners:
+              - ''
+          5985:
+              service_names: []
+              banners:
+              - ''
+          5986:
+              service_names: []
+              banners:
+              - ''
+          9389:
+              service_names: []
+              banners:
+              - ''
+          49666:
+              service_names: []
+              banners:
+              - ''
+          49667:
+              service_names: []
+              banners:
+              - ''
+          49675:
+              service_names: []
+              banners:
+              - ''
+          49676:
+              service_names: []
+              banners:
+              - ''
+          49678:
+              service_names: []
+              banners:
+              - ''
+          49693:
+              service_names: []
+              banners:
+              - ''
+          60064:
+              service_names: []
+              banners:
+              - ''
+      udp_ports: {}
+      os: []
+  192.168.56.11:
+      hostnames: []
+      tcp_ports:
+          53:
+              service_names: []
+              banners:
+              - ''
+          135:
+              service_names: []
+              banners:
+              - ''
+          139:
+              service_names: []
+              banners:
+              - ''
+          445:
+              service_names: []
+              banners:
+              - ''
+          3389:
+              service_names: []
+              banners:
+              - ''
+          5985:
+              service_names: []
+              banners:
+              - ''
+          5986:
+              service_names: []
+              banners:
+              - ''
+          49666:
+              service_names: []
+              banners:
+              - ''
+          49667:
+              service_names: []
+              banners:
+              - ''
+          49674:
+              service_names: []
+              banners:
+              - ''
+          49728:
+              service_names: []
+              banners:
+              - ''
+      udp_ports: {}
+      os: []
+  192.168.56.22:
+      hostnames: []
+      tcp_ports:
+          3389:
+              service_names: []
+              banners:
+              - ''
+          5985:
+              service_names: []
+              banners:
+              - ''
+          5986:
+              service_names: []
+              banners:
+              - ''
+      udp_ports: {}
+      os: []
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/ipv6/nessus/google_ipv6_tp0mpn.nessus -w terminal]
+  '''
+  ╒══════════════════════════╤═══════════════════════════╤═════════╤════════════╤═══════════╤══════╕
+  │ IP-Addresses             │ Hostnames                 │ Ports   │ Services   │ Banners   │ OS   │
+  ╞══════════════════════════╪═══════════════════════════╪═════════╪════════════╪═══════════╪══════╡
+  │ 2a00:1450:4001:828::200e │ fra24s05-in-x0e.1e100.net │ 80/tcp  │ www        │ gws       │      │
+  │                          │ g.co                      │ 443/tcp │ www        │ gws       │      │
+  │                          │ google.com                │ 443/udp │ https?     │           │      │
+  │                          │ music.youtube.com         │         │            │           │      │
+  │                          │ www.goo.gl                │         │            │           │      │
+  ╘══════════════════════════╧═══════════════════════════╧═════════╧════════════╧═══════════╧══════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w aquatone --multi-table]
+  '''
+  http://192.168.56.10:123
+  http://192.168.56.10:135
+  http://192.168.56.10:137
+  http://192.168.56.10:139
+  http://192.168.56.10:3268
+  http://192.168.56.10:3269
+  http://192.168.56.10:3389
+  http://192.168.56.10:389
+  http://192.168.56.10:445
+  http://192.168.56.10:464
+  http://192.168.56.10:47001
+  http://192.168.56.10:49664
+  http://192.168.56.10:49665
+  http://192.168.56.10:49666
+  http://192.168.56.10:49667
+  http://192.168.56.10:49669
+  http://192.168.56.10:49670
+  http://192.168.56.10:49672
+  http://192.168.56.10:49675
+  http://192.168.56.10:49685
+  http://192.168.56.10:49785
+  http://192.168.56.10:49863
+  http://192.168.56.10:49966
+  http://192.168.56.10:53
+  http://192.168.56.10:5355
+  http://192.168.56.10:593
+  http://192.168.56.10:5985
+  http://192.168.56.10:5986
+  http://192.168.56.10:636
+  http://192.168.56.10:80
+  http://192.168.56.10:88
+  http://192.168.56.10:9389
+  http://192.168.56.11:123
+  http://192.168.56.11:135
+  http://192.168.56.11:137
+  http://192.168.56.11:139
+  http://192.168.56.11:3268
+  http://192.168.56.11:3269
+  http://192.168.56.11:3389
+  http://192.168.56.11:389
+  http://192.168.56.11:445
+  http://192.168.56.11:464
+  http://192.168.56.11:47001
+  http://192.168.56.11:49664
+  http://192.168.56.11:49665
+  http://192.168.56.11:49666
+  http://192.168.56.11:49667
+  http://192.168.56.11:49669
+  http://192.168.56.11:49670
+  http://192.168.56.11:49673
+  http://192.168.56.11:49676
+  http://192.168.56.11:49722
+  http://192.168.56.11:53
+  http://192.168.56.11:5355
+  http://192.168.56.11:593
+  http://192.168.56.11:5985
+  http://192.168.56.11:5986
+  http://192.168.56.11:636
+  http://192.168.56.11:65363
+  http://192.168.56.11:65464
+  http://192.168.56.11:88
+  http://192.168.56.11:9389
+  http://192.168.56.22:135
+  http://192.168.56.22:137
+  http://192.168.56.22:139
+  http://192.168.56.22:1433
+  http://192.168.56.22:3389
+  http://192.168.56.22:445
+  http://192.168.56.22:47001
+  http://192.168.56.22:49664
+  http://192.168.56.22:49665
+  http://192.168.56.22:49666
+  http://192.168.56.22:49667
+  http://192.168.56.22:49668
+  http://192.168.56.22:49669
+  http://192.168.56.22:49682
+  http://192.168.56.22:49734
+  http://192.168.56.22:49813
+  http://192.168.56.22:5355
+  http://192.168.56.22:5985
+  http://192.168.56.22:5986
+  http://192.168.56.22:80
+  https://192.168.56.10:123
+  https://192.168.56.10:135
+  https://192.168.56.10:137
+  https://192.168.56.10:139
+  https://192.168.56.10:3268
+  https://192.168.56.10:3269
+  https://192.168.56.10:3389
+  https://192.168.56.10:389
+  https://192.168.56.10:445
+  https://192.168.56.10:464
+  https://192.168.56.10:47001
+  https://192.168.56.10:49664
+  https://192.168.56.10:49665
+  https://192.168.56.10:49666
+  https://192.168.56.10:49667
+  https://192.168.56.10:49669
+  https://192.168.56.10:49670
+  https://192.168.56.10:49672
+  https://192.168.56.10:49675
+  https://192.168.56.10:49685
+  https://192.168.56.10:49785
+  https://192.168.56.10:49863
+  https://192.168.56.10:49966
+  https://192.168.56.10:53
+  https://192.168.56.10:5355
+  https://192.168.56.10:593
+  https://192.168.56.10:5985
+  https://192.168.56.10:5986
+  https://192.168.56.10:636
+  https://192.168.56.10:80
+  https://192.168.56.10:88
+  https://192.168.56.10:9389
+  https://192.168.56.11:123
+  https://192.168.56.11:135
+  https://192.168.56.11:137
+  https://192.168.56.11:139
+  https://192.168.56.11:3268
+  https://192.168.56.11:3269
+  https://192.168.56.11:3389
+  https://192.168.56.11:389
+  https://192.168.56.11:445
+  https://192.168.56.11:464
+  https://192.168.56.11:47001
+  https://192.168.56.11:49664
+  https://192.168.56.11:49665
+  https://192.168.56.11:49666
+  https://192.168.56.11:49667
+  https://192.168.56.11:49669
+  https://192.168.56.11:49670
+  https://192.168.56.11:49673
+  https://192.168.56.11:49676
+  https://192.168.56.11:49722
+  https://192.168.56.11:53
+  https://192.168.56.11:5355
+  https://192.168.56.11:593
+  https://192.168.56.11:5985
+  https://192.168.56.11:5986
+  https://192.168.56.11:636
+  https://192.168.56.11:65363
+  https://192.168.56.11:65464
+  https://192.168.56.11:88
+  https://192.168.56.11:9389
+  https://192.168.56.22:135
+  https://192.168.56.22:137
+  https://192.168.56.22:139
+  https://192.168.56.22:1433
+  https://192.168.56.22:3389
+  https://192.168.56.22:445
+  https://192.168.56.22:47001
+  https://192.168.56.22:49664
+  https://192.168.56.22:49665
+  https://192.168.56.22:49666
+  https://192.168.56.22:49667
+  https://192.168.56.22:49668
+  https://192.168.56.22:49669
+  https://192.168.56.22:49682
+  https://192.168.56.22:49734
+  https://192.168.56.22:49813
+  https://192.168.56.22:5355
+  https://192.168.56.22:5985
+  https://192.168.56.22:5986
+  https://192.168.56.22:80
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w aquatone]
+  '''
+  http://192.168.56.10:123
+  http://192.168.56.10:135
+  http://192.168.56.10:137
+  http://192.168.56.10:139
+  http://192.168.56.10:3268
+  http://192.168.56.10:3269
+  http://192.168.56.10:3389
+  http://192.168.56.10:389
+  http://192.168.56.10:445
+  http://192.168.56.10:464
+  http://192.168.56.10:47001
+  http://192.168.56.10:49664
+  http://192.168.56.10:49665
+  http://192.168.56.10:49666
+  http://192.168.56.10:49667
+  http://192.168.56.10:49669
+  http://192.168.56.10:49670
+  http://192.168.56.10:49672
+  http://192.168.56.10:49675
+  http://192.168.56.10:49685
+  http://192.168.56.10:49785
+  http://192.168.56.10:49863
+  http://192.168.56.10:49966
+  http://192.168.56.10:53
+  http://192.168.56.10:5355
+  http://192.168.56.10:593
+  http://192.168.56.10:5985
+  http://192.168.56.10:5986
+  http://192.168.56.10:636
+  http://192.168.56.10:80
+  http://192.168.56.10:88
+  http://192.168.56.10:9389
+  http://192.168.56.11:123
+  http://192.168.56.11:135
+  http://192.168.56.11:137
+  http://192.168.56.11:139
+  http://192.168.56.11:3268
+  http://192.168.56.11:3269
+  http://192.168.56.11:3389
+  http://192.168.56.11:389
+  http://192.168.56.11:445
+  http://192.168.56.11:464
+  http://192.168.56.11:47001
+  http://192.168.56.11:49664
+  http://192.168.56.11:49665
+  http://192.168.56.11:49666
+  http://192.168.56.11:49667
+  http://192.168.56.11:49669
+  http://192.168.56.11:49670
+  http://192.168.56.11:49673
+  http://192.168.56.11:49676
+  http://192.168.56.11:49722
+  http://192.168.56.11:53
+  http://192.168.56.11:5355
+  http://192.168.56.11:593
+  http://192.168.56.11:5985
+  http://192.168.56.11:5986
+  http://192.168.56.11:636
+  http://192.168.56.11:65363
+  http://192.168.56.11:65464
+  http://192.168.56.11:88
+  http://192.168.56.11:9389
+  http://192.168.56.22:135
+  http://192.168.56.22:137
+  http://192.168.56.22:139
+  http://192.168.56.22:1433
+  http://192.168.56.22:3389
+  http://192.168.56.22:445
+  http://192.168.56.22:47001
+  http://192.168.56.22:49664
+  http://192.168.56.22:49665
+  http://192.168.56.22:49666
+  http://192.168.56.22:49667
+  http://192.168.56.22:49668
+  http://192.168.56.22:49669
+  http://192.168.56.22:49682
+  http://192.168.56.22:49734
+  http://192.168.56.22:49813
+  http://192.168.56.22:5355
+  http://192.168.56.22:5985
+  http://192.168.56.22:5986
+  http://192.168.56.22:80
+  https://192.168.56.10:123
+  https://192.168.56.10:135
+  https://192.168.56.10:137
+  https://192.168.56.10:139
+  https://192.168.56.10:3268
+  https://192.168.56.10:3269
+  https://192.168.56.10:3389
+  https://192.168.56.10:389
+  https://192.168.56.10:445
+  https://192.168.56.10:464
+  https://192.168.56.10:47001
+  https://192.168.56.10:49664
+  https://192.168.56.10:49665
+  https://192.168.56.10:49666
+  https://192.168.56.10:49667
+  https://192.168.56.10:49669
+  https://192.168.56.10:49670
+  https://192.168.56.10:49672
+  https://192.168.56.10:49675
+  https://192.168.56.10:49685
+  https://192.168.56.10:49785
+  https://192.168.56.10:49863
+  https://192.168.56.10:49966
+  https://192.168.56.10:53
+  https://192.168.56.10:5355
+  https://192.168.56.10:593
+  https://192.168.56.10:5985
+  https://192.168.56.10:5986
+  https://192.168.56.10:636
+  https://192.168.56.10:80
+  https://192.168.56.10:88
+  https://192.168.56.10:9389
+  https://192.168.56.11:123
+  https://192.168.56.11:135
+  https://192.168.56.11:137
+  https://192.168.56.11:139
+  https://192.168.56.11:3268
+  https://192.168.56.11:3269
+  https://192.168.56.11:3389
+  https://192.168.56.11:389
+  https://192.168.56.11:445
+  https://192.168.56.11:464
+  https://192.168.56.11:47001
+  https://192.168.56.11:49664
+  https://192.168.56.11:49665
+  https://192.168.56.11:49666
+  https://192.168.56.11:49667
+  https://192.168.56.11:49669
+  https://192.168.56.11:49670
+  https://192.168.56.11:49673
+  https://192.168.56.11:49676
+  https://192.168.56.11:49722
+  https://192.168.56.11:53
+  https://192.168.56.11:5355
+  https://192.168.56.11:593
+  https://192.168.56.11:5985
+  https://192.168.56.11:5986
+  https://192.168.56.11:636
+  https://192.168.56.11:65363
+  https://192.168.56.11:65464
+  https://192.168.56.11:88
+  https://192.168.56.11:9389
+  https://192.168.56.22:135
+  https://192.168.56.22:137
+  https://192.168.56.22:139
+  https://192.168.56.22:1433
+  https://192.168.56.22:3389
+  https://192.168.56.22:445
+  https://192.168.56.22:47001
+  https://192.168.56.22:49664
+  https://192.168.56.22:49665
+  https://192.168.56.22:49666
+  https://192.168.56.22:49667
+  https://192.168.56.22:49668
+  https://192.168.56.22:49669
+  https://192.168.56.22:49682
+  https://192.168.56.22:49734
+  https://192.168.56.22:49813
+  https://192.168.56.22:5355
+  https://192.168.56.22:5985
+  https://192.168.56.22:5986
+  https://192.168.56.22:80
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w csv --multi-table]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  192.168.56.10,,53/tcp,dns,,windows
+  192.168.56.10,,53/udp,dns,,windows
+  192.168.56.10,,80/tcp,www,Microsoft\-IIS/10.0,windows
+  192.168.56.10,,88/tcp,kerberos?,,windows
+  192.168.56.10,,123/udp,ntp,,windows
+  192.168.56.10,,135/tcp,epmap,,windows
+  192.168.56.10,,137/udp,netbios\-ns,,windows
+  192.168.56.10,,139/tcp,smb,,windows
+  192.168.56.10,,389/tcp,ldap,,windows
+  192.168.56.10,,445/tcp,cifs,,windows
+  192.168.56.10,,464/tcp,kpasswd?,,windows
+  192.168.56.10,,593/tcp,http\-rpc\-epmap,,windows
+  192.168.56.10,,636/tcp,ldap,,windows
+  192.168.56.10,,3268/tcp,ldap,,windows
+  192.168.56.10,,3269/tcp,ldap,,windows
+  192.168.56.10,,3389/tcp,msrdp,,windows
+  192.168.56.10,,5355/udp,llmnr,,windows
+  192.168.56.10,,5985/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.10,,5986/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.10,,9389/tcp,,,windows
+  192.168.56.10,,47001/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.10,,49664/tcp,dce\-rpc,,windows
+  192.168.56.10,,49665/tcp,dce\-rpc,,windows
+  192.168.56.10,,49666/tcp,dce\-rpc,,windows
+  192.168.56.10,,49667/tcp,dce\-rpc,,windows
+  192.168.56.10,,49669/tcp,ncacn_http,,windows
+  192.168.56.10,,49670/tcp,dce\-rpc,,windows
+  192.168.56.10,,49672/tcp,dce\-rpc,,windows
+  192.168.56.10,,49675/tcp,dce\-rpc,,windows
+  192.168.56.10,,49685/tcp,dce\-rpc,,windows
+  192.168.56.10,,49785/tcp,dce\-rpc,,windows
+  192.168.56.10,,49863/tcp,dce\-rpc,,windows
+  192.168.56.10,,49966/tcp,dce\-rpc,,windows
+  192.168.56.11,,53/tcp,dns,,windows
+  192.168.56.11,,53/udp,dns,,windows
+  192.168.56.11,,88/tcp,kerberos?,,windows
+  192.168.56.11,,123/udp,ntp,,windows
+  192.168.56.11,,135/tcp,epmap,,windows
+  192.168.56.11,,137/udp,netbios\-ns,,windows
+  192.168.56.11,,139/tcp,smb,,windows
+  192.168.56.11,,389/tcp,ldap,,windows
+  192.168.56.11,,445/tcp,cifs,,windows
+  192.168.56.11,,464/tcp,kpasswd?,,windows
+  192.168.56.11,,593/tcp,http\-rpc\-epmap,,windows
+  192.168.56.11,,636/tcp,ldap,,windows
+  192.168.56.11,,3268/tcp,ldap,,windows
+  192.168.56.11,,3269/tcp,ldap,,windows
+  192.168.56.11,,3389/tcp,msrdp,,windows
+  192.168.56.11,,5355/udp,llmnr,,windows
+  192.168.56.11,,5985/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.11,,5986/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.11,,9389/tcp,,,windows
+  192.168.56.11,,47001/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.11,,49664/tcp,dce\-rpc,,windows
+  192.168.56.11,,49665/tcp,dce\-rpc,,windows
+  192.168.56.11,,49666/tcp,dce\-rpc,,windows
+  192.168.56.11,,49667/tcp,dce\-rpc,,windows
+  192.168.56.11,,49669/tcp,dce\-rpc,,windows
+  192.168.56.11,,49670/tcp,ncacn_http,,windows
+  192.168.56.11,,49673/tcp,dce\-rpc,,windows
+  192.168.56.11,,49676/tcp,dce\-rpc,,windows
+  192.168.56.11,,49722/tcp,dce\-rpc,,windows
+  192.168.56.11,,65363/tcp,dce\-rpc,,windows
+  192.168.56.11,,65464/tcp,dce\-rpc,,windows
+  192.168.56.22,,80/tcp,www,Microsoft\-IIS/10.0,windows
+  192.168.56.22,,135/tcp,epmap,,windows
+  192.168.56.22,,137/udp,netbios\-ns,,windows
+  192.168.56.22,,139/tcp,smb,,windows
+  192.168.56.22,,445/tcp,cifs,,windows
+  192.168.56.22,,1433/tcp,mssql,,windows
+  192.168.56.22,,3389/tcp,msrdp,,windows
+  192.168.56.22,,5355/udp,llmnr,,windows
+  192.168.56.22,,5985/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.22,,5986/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.22,,47001/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.22,,49664/tcp,dce\-rpc,,windows
+  192.168.56.22,,49665/tcp,dce\-rpc,,windows
+  192.168.56.22,,49666/tcp,dce\-rpc,,windows
+  192.168.56.22,,49667/tcp,dce\-rpc,,windows
+  192.168.56.22,,49668/tcp,dce\-rpc,,windows
+  192.168.56.22,,49669/tcp,dce\-rpc,,windows
+  192.168.56.22,,49682/tcp,dce\-rpc,,windows
+  192.168.56.22,,49734/tcp,dce\-rpc,,windows
+  192.168.56.22,,49813/tcp,sybase,,windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w csv]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  192.168.56.10,,53/tcp,dns,,windows
+  192.168.56.10,,53/udp,dns,,windows
+  192.168.56.10,,80/tcp,www,Microsoft\-IIS/10.0,windows
+  192.168.56.10,,88/tcp,kerberos?,,windows
+  192.168.56.10,,123/udp,ntp,,windows
+  192.168.56.10,,135/tcp,epmap,,windows
+  192.168.56.10,,137/udp,netbios\-ns,,windows
+  192.168.56.10,,139/tcp,smb,,windows
+  192.168.56.10,,389/tcp,ldap,,windows
+  192.168.56.10,,445/tcp,cifs,,windows
+  192.168.56.10,,464/tcp,kpasswd?,,windows
+  192.168.56.10,,593/tcp,http\-rpc\-epmap,,windows
+  192.168.56.10,,636/tcp,ldap,,windows
+  192.168.56.10,,3268/tcp,ldap,,windows
+  192.168.56.10,,3269/tcp,ldap,,windows
+  192.168.56.10,,3389/tcp,msrdp,,windows
+  192.168.56.10,,5355/udp,llmnr,,windows
+  192.168.56.10,,5985/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.10,,5986/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.10,,9389/tcp,,,windows
+  192.168.56.10,,47001/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.10,,49664/tcp,dce\-rpc,,windows
+  192.168.56.10,,49665/tcp,dce\-rpc,,windows
+  192.168.56.10,,49666/tcp,dce\-rpc,,windows
+  192.168.56.10,,49667/tcp,dce\-rpc,,windows
+  192.168.56.10,,49669/tcp,ncacn_http,,windows
+  192.168.56.10,,49670/tcp,dce\-rpc,,windows
+  192.168.56.10,,49672/tcp,dce\-rpc,,windows
+  192.168.56.10,,49675/tcp,dce\-rpc,,windows
+  192.168.56.10,,49685/tcp,dce\-rpc,,windows
+  192.168.56.10,,49785/tcp,dce\-rpc,,windows
+  192.168.56.10,,49863/tcp,dce\-rpc,,windows
+  192.168.56.10,,49966/tcp,dce\-rpc,,windows
+  192.168.56.11,,53/tcp,dns,,windows
+  192.168.56.11,,53/udp,dns,,windows
+  192.168.56.11,,88/tcp,kerberos?,,windows
+  192.168.56.11,,123/udp,ntp,,windows
+  192.168.56.11,,135/tcp,epmap,,windows
+  192.168.56.11,,137/udp,netbios\-ns,,windows
+  192.168.56.11,,139/tcp,smb,,windows
+  192.168.56.11,,389/tcp,ldap,,windows
+  192.168.56.11,,445/tcp,cifs,,windows
+  192.168.56.11,,464/tcp,kpasswd?,,windows
+  192.168.56.11,,593/tcp,http\-rpc\-epmap,,windows
+  192.168.56.11,,636/tcp,ldap,,windows
+  192.168.56.11,,3268/tcp,ldap,,windows
+  192.168.56.11,,3269/tcp,ldap,,windows
+  192.168.56.11,,3389/tcp,msrdp,,windows
+  192.168.56.11,,5355/udp,llmnr,,windows
+  192.168.56.11,,5985/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.11,,5986/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.11,,9389/tcp,,,windows
+  192.168.56.11,,47001/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.11,,49664/tcp,dce\-rpc,,windows
+  192.168.56.11,,49665/tcp,dce\-rpc,,windows
+  192.168.56.11,,49666/tcp,dce\-rpc,,windows
+  192.168.56.11,,49667/tcp,dce\-rpc,,windows
+  192.168.56.11,,49669/tcp,dce\-rpc,,windows
+  192.168.56.11,,49670/tcp,ncacn_http,,windows
+  192.168.56.11,,49673/tcp,dce\-rpc,,windows
+  192.168.56.11,,49676/tcp,dce\-rpc,,windows
+  192.168.56.11,,49722/tcp,dce\-rpc,,windows
+  192.168.56.11,,65363/tcp,dce\-rpc,,windows
+  192.168.56.11,,65464/tcp,dce\-rpc,,windows
+  192.168.56.22,,80/tcp,www,Microsoft\-IIS/10.0,windows
+  192.168.56.22,,135/tcp,epmap,,windows
+  192.168.56.22,,137/udp,netbios\-ns,,windows
+  192.168.56.22,,139/tcp,smb,,windows
+  192.168.56.22,,445/tcp,cifs,,windows
+  192.168.56.22,,1433/tcp,mssql,,windows
+  192.168.56.22,,3389/tcp,msrdp,,windows
+  192.168.56.22,,5355/udp,llmnr,,windows
+  192.168.56.22,,5985/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.22,,5986/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.22,,47001/tcp,www,Microsoft\-HTTPAPI/2.0,windows
+  192.168.56.22,,49664/tcp,dce\-rpc,,windows
+  192.168.56.22,,49665/tcp,dce\-rpc,,windows
+  192.168.56.22,,49666/tcp,dce\-rpc,,windows
+  192.168.56.22,,49667/tcp,dce\-rpc,,windows
+  192.168.56.22,,49668/tcp,dce\-rpc,,windows
+  192.168.56.22,,49669/tcp,dce\-rpc,,windows
+  192.168.56.22,,49682/tcp,dce\-rpc,,windows
+  192.168.56.22,,49734/tcp,dce\-rpc,,windows
+  192.168.56.22,,49813/tcp,sybase,,windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w host --multi-table]
+  '''
+  192.168.56.10
+  192.168.56.11
+  192.168.56.22
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w host]
+  '''
+  192.168.56.10
+  192.168.56.11
+  192.168.56.22
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w html --multi-table]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.10</th>
+        <th></th>
+        <th>windows</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>53/tcp</td>
+        <td>dns</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>53/udp</td>
+        <td>dns</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>80/tcp</td>
+        <td>www</td>
+        <td>Microsoft-IIS/10.0</td>
+      </tr>
+      <tr>
+        <td>88/tcp</td>
+        <td>kerberos?</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>123/udp</td>
+        <td>ntp</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>135/tcp</td>
+        <td>epmap</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>137/udp</td>
+        <td>netbios-ns</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>139/tcp</td>
+        <td>smb</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>389/tcp</td>
+        <td>ldap</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>445/tcp</td>
+        <td>cifs</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>464/tcp</td>
+        <td>kpasswd?</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>593/tcp</td>
+        <td>http-rpc-epmap</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>636/tcp</td>
+        <td>ldap</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>3268/tcp</td>
+        <td>ldap</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>3269/tcp</td>
+        <td>ldap</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>3389/tcp</td>
+        <td>msrdp</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>5355/udp</td>
+        <td>llmnr</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>5985/tcp</td>
+        <td>www</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+      <tr>
+        <td>5986/tcp</td>
+        <td>www</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+      <tr>
+        <td>9389/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>47001/tcp</td>
+        <td>www</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+      <tr>
+        <td>49664/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49665/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49666/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49667/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49669/tcp</td>
+        <td>ncacn_http</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49670/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49672/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49675/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49685/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49785/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49863/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49966/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.11</th>
+        <th></th>
+        <th>windows</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>53/tcp</td>
+        <td>dns</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>53/udp</td>
+        <td>dns</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>88/tcp</td>
+        <td>kerberos?</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>123/udp</td>
+        <td>ntp</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>135/tcp</td>
+        <td>epmap</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>137/udp</td>
+        <td>netbios-ns</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>139/tcp</td>
+        <td>smb</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>389/tcp</td>
+        <td>ldap</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>445/tcp</td>
+        <td>cifs</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>464/tcp</td>
+        <td>kpasswd?</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>593/tcp</td>
+        <td>http-rpc-epmap</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>636/tcp</td>
+        <td>ldap</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>3268/tcp</td>
+        <td>ldap</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>3269/tcp</td>
+        <td>ldap</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>3389/tcp</td>
+        <td>msrdp</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>5355/udp</td>
+        <td>llmnr</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>5985/tcp</td>
+        <td>www</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+      <tr>
+        <td>5986/tcp</td>
+        <td>www</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+      <tr>
+        <td>9389/tcp</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>47001/tcp</td>
+        <td>www</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+      <tr>
+        <td>49664/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49665/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49666/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49667/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49669/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49670/tcp</td>
+        <td>ncacn_http</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49673/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49676/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49722/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>65363/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>65464/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.22</th>
+        <th></th>
+        <th>windows</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>80/tcp</td>
+        <td>www</td>
+        <td>Microsoft-IIS/10.0</td>
+      </tr>
+      <tr>
+        <td>135/tcp</td>
+        <td>epmap</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>137/udp</td>
+        <td>netbios-ns</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>139/tcp</td>
+        <td>smb</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>445/tcp</td>
+        <td>cifs</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>1433/tcp</td>
+        <td>mssql</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>3389/tcp</td>
+        <td>msrdp</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>5355/udp</td>
+        <td>llmnr</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>5985/tcp</td>
+        <td>www</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+      <tr>
+        <td>5986/tcp</td>
+        <td>www</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+      <tr>
+        <td>47001/tcp</td>
+        <td>www</td>
+        <td>Microsoft-HTTPAPI/2.0</td>
+      </tr>
+      <tr>
+        <td>49664/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49665/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49666/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49667/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49668/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49669/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49682/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49734/tcp</td>
+        <td>dce-rpc</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>49813/tcp</td>
+        <td>sybase</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w html]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>IP-Addresses</th>
+        <th>Hostnames</th>
+        <th>Ports</th>
+        <th>Services</th>
+        <th>Banners</th>
+        <th>OS</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>192.168.56.10</td>
+        <td></td>
+        <td>53/tcp<br>53/udp<br>80/tcp<br>88/tcp<br>123/udp<br>135/tcp<br>137/udp<br>139/tcp<br>389/tcp<br>445/tcp<br>464/tcp<br>593/tcp<br>636/tcp<br>3268/tcp<br>3269/tcp<br>3389/tcp<br>5355/udp<br>5985/tcp<br>5986/tcp<br>9389/tcp<br>47001/tcp<br>49664/tcp<br>49665/tcp<br>49666/tcp<br>49667/tcp<br>49669/tcp<br>49670/tcp<br>49672/tcp<br>49675/tcp<br>49685/tcp<br>49785/tcp<br>49863/tcp<br>49966/tcp</td>
+        <td>dns<br>dns<br>www<br>kerberos?<br>ntp<br>epmap<br>netbios-ns<br>smb<br>ldap<br>cifs<br>kpasswd?<br>http-rpc-epmap<br>ldap<br>ldap<br>ldap<br>msrdp<br>llmnr<br>www<br>www<br><br>www<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>ncacn_http<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc</td>
+        <td><br><br>Microsoft-IIS/10.0<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0<br><br>Microsoft-HTTPAPI/2.0<br><br><br><br><br><br><br><br><br><br><br><br></td>
+        <td>windows</td>
+      </tr>
+      <tr>
+        <td>192.168.56.11</td>
+        <td></td>
+        <td>53/tcp<br>53/udp<br>88/tcp<br>123/udp<br>135/tcp<br>137/udp<br>139/tcp<br>389/tcp<br>445/tcp<br>464/tcp<br>593/tcp<br>636/tcp<br>3268/tcp<br>3269/tcp<br>3389/tcp<br>5355/udp<br>5985/tcp<br>5986/tcp<br>9389/tcp<br>47001/tcp<br>49664/tcp<br>49665/tcp<br>49666/tcp<br>49667/tcp<br>49669/tcp<br>49670/tcp<br>49673/tcp<br>49676/tcp<br>49722/tcp<br>65363/tcp<br>65464/tcp</td>
+        <td>dns<br>dns<br>kerberos?<br>ntp<br>epmap<br>netbios-ns<br>smb<br>ldap<br>cifs<br>kpasswd?<br>http-rpc-epmap<br>ldap<br>ldap<br>ldap<br>msrdp<br>llmnr<br>www<br>www<br><br>www<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>ncacn_http<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc</td>
+        <td><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0<br><br>Microsoft-HTTPAPI/2.0<br><br><br><br><br><br><br><br><br><br><br></td>
+        <td>windows</td>
+      </tr>
+      <tr>
+        <td>192.168.56.22</td>
+        <td></td>
+        <td>80/tcp<br>135/tcp<br>137/udp<br>139/tcp<br>445/tcp<br>1433/tcp<br>3389/tcp<br>5355/udp<br>5985/tcp<br>5986/tcp<br>47001/tcp<br>49664/tcp<br>49665/tcp<br>49666/tcp<br>49667/tcp<br>49668/tcp<br>49669/tcp<br>49682/tcp<br>49734/tcp<br>49813/tcp</td>
+        <td>www<br>epmap<br>netbios-ns<br>smb<br>cifs<br>mssql<br>msrdp<br>llmnr<br>www<br>www<br>www<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>sybase</td>
+        <td>Microsoft-IIS/10.0<br><br><br><br><br><br><br><br>Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0<br><br><br><br><br><br><br><br><br></td>
+        <td>windows</td>
+      </tr>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w json --multi-table]
+  '''
+  {"192.168.56.10":{"hostnames":[],"tcp_ports":{"53":{"service_names":["dns"],"banners":[""]},"80":{"service_names":["www"],"banners":["Microsoft-IIS\/10.0"]},"88":{"service_names":["kerberos?"],"banners":[""]},"135":{"service_names":["epmap"],"banners":[""]},"139":{"service_names":["smb"],"banners":[""]},"389":{"service_names":["ldap"],"banners":[""]},"445":{"service_names":["cifs"],"banners":[""]},"464":{"service_names":["kpasswd?"],"banners":[""]},"593":{"service_names":["http-rpc-epmap"],"banners":[""]},"636":{"service_names":["ldap"],"banners":[""]},"3268":{"service_names":["ldap"],"banners":[""]},"3269":{"service_names":["ldap"],"banners":[""]},"3389":{"service_names":["msrdp"],"banners":[""]},"5985":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"5986":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"9389":{"service_names":[],"banners":[""]},"47001":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"49664":{"service_names":["dce-rpc"],"banners":[""]},"49665":{"service_names":["dce-rpc"],"banners":[""]},"49666":{"service_names":["dce-rpc"],"banners":[""]},"49667":{"service_names":["dce-rpc"],"banners":[""]},"49669":{"service_names":["ncacn_http"],"banners":[""]},"49670":{"service_names":["dce-rpc"],"banners":[""]},"49672":{"service_names":["dce-rpc"],"banners":[""]},"49675":{"service_names":["dce-rpc"],"banners":[""]},"49685":{"service_names":["dce-rpc"],"banners":[""]},"49785":{"service_names":["dce-rpc"],"banners":[""]},"49863":{"service_names":["dce-rpc"],"banners":[""]},"49966":{"service_names":["dce-rpc"],"banners":[""]}},"udp_ports":{"53":{"service_names":["dns"],"banners":[""]},"123":{"service_names":["ntp"],"banners":[""]},"137":{"service_names":["netbios-ns"],"banners":[""]},"5355":{"service_names":["llmnr"],"banners":[""]}},"os":["windows"]},"192.168.56.11":{"hostnames":[],"tcp_ports":{"53":{"service_names":["dns"],"banners":[""]},"88":{"service_names":["kerberos?"],"banners":[""]},"135":{"service_names":["epmap"],"banners":[""]},"139":{"service_names":["smb"],"banners":[""]},"389":{"service_names":["ldap"],"banners":[""]},"445":{"service_names":["cifs"],"banners":[""]},"464":{"service_names":["kpasswd?"],"banners":[""]},"593":{"service_names":["http-rpc-epmap"],"banners":[""]},"636":{"service_names":["ldap"],"banners":[""]},"3268":{"service_names":["ldap"],"banners":[""]},"3269":{"service_names":["ldap"],"banners":[""]},"3389":{"service_names":["msrdp"],"banners":[""]},"5985":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"5986":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"9389":{"service_names":[],"banners":[""]},"47001":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"49664":{"service_names":["dce-rpc"],"banners":[""]},"49665":{"service_names":["dce-rpc"],"banners":[""]},"49666":{"service_names":["dce-rpc"],"banners":[""]},"49667":{"service_names":["dce-rpc"],"banners":[""]},"49669":{"service_names":["dce-rpc"],"banners":[""]},"49670":{"service_names":["ncacn_http"],"banners":[""]},"49673":{"service_names":["dce-rpc"],"banners":[""]},"49676":{"service_names":["dce-rpc"],"banners":[""]},"49722":{"service_names":["dce-rpc"],"banners":[""]},"65363":{"service_names":["dce-rpc"],"banners":[""]},"65464":{"service_names":["dce-rpc"],"banners":[""]}},"udp_ports":{"53":{"service_names":["dns"],"banners":[""]},"123":{"service_names":["ntp"],"banners":[""]},"137":{"service_names":["netbios-ns"],"banners":[""]},"5355":{"service_names":["llmnr"],"banners":[""]}},"os":["windows"]},"192.168.56.22":{"hostnames":[],"tcp_ports":{"80":{"service_names":["www"],"banners":["Microsoft-IIS\/10.0"]},"135":{"service_names":["epmap"],"banners":[""]},"139":{"service_names":["smb"],"banners":[""]},"445":{"service_names":["cifs"],"banners":[""]},"1433":{"service_names":["mssql"],"banners":[""]},"3389":{"service_names":["msrdp"],"banners":[""]},"5985":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"5986":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"47001":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"49664":{"service_names":["dce-rpc"],"banners":[""]},"49665":{"service_names":["dce-rpc"],"banners":[""]},"49666":{"service_names":["dce-rpc"],"banners":[""]},"49667":{"service_names":["dce-rpc"],"banners":[""]},"49668":{"service_names":["dce-rpc"],"banners":[""]},"49669":{"service_names":["dce-rpc"],"banners":[""]},"49682":{"service_names":["dce-rpc"],"banners":[""]},"49734":{"service_names":["dce-rpc"],"banners":[""]},"49813":{"service_names":["sybase"],"banners":[""]}},"udp_ports":{"137":{"service_names":["netbios-ns"],"banners":[""]},"5355":{"service_names":["llmnr"],"banners":[""]}},"os":["windows"]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w json]
+  '''
+  {"192.168.56.10":{"hostnames":[],"tcp_ports":{"53":{"service_names":["dns"],"banners":[""]},"80":{"service_names":["www"],"banners":["Microsoft-IIS\/10.0"]},"88":{"service_names":["kerberos?"],"banners":[""]},"135":{"service_names":["epmap"],"banners":[""]},"139":{"service_names":["smb"],"banners":[""]},"389":{"service_names":["ldap"],"banners":[""]},"445":{"service_names":["cifs"],"banners":[""]},"464":{"service_names":["kpasswd?"],"banners":[""]},"593":{"service_names":["http-rpc-epmap"],"banners":[""]},"636":{"service_names":["ldap"],"banners":[""]},"3268":{"service_names":["ldap"],"banners":[""]},"3269":{"service_names":["ldap"],"banners":[""]},"3389":{"service_names":["msrdp"],"banners":[""]},"5985":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"5986":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"9389":{"service_names":[],"banners":[""]},"47001":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"49664":{"service_names":["dce-rpc"],"banners":[""]},"49665":{"service_names":["dce-rpc"],"banners":[""]},"49666":{"service_names":["dce-rpc"],"banners":[""]},"49667":{"service_names":["dce-rpc"],"banners":[""]},"49669":{"service_names":["ncacn_http"],"banners":[""]},"49670":{"service_names":["dce-rpc"],"banners":[""]},"49672":{"service_names":["dce-rpc"],"banners":[""]},"49675":{"service_names":["dce-rpc"],"banners":[""]},"49685":{"service_names":["dce-rpc"],"banners":[""]},"49785":{"service_names":["dce-rpc"],"banners":[""]},"49863":{"service_names":["dce-rpc"],"banners":[""]},"49966":{"service_names":["dce-rpc"],"banners":[""]}},"udp_ports":{"53":{"service_names":["dns"],"banners":[""]},"123":{"service_names":["ntp"],"banners":[""]},"137":{"service_names":["netbios-ns"],"banners":[""]},"5355":{"service_names":["llmnr"],"banners":[""]}},"os":["windows"]},"192.168.56.11":{"hostnames":[],"tcp_ports":{"53":{"service_names":["dns"],"banners":[""]},"88":{"service_names":["kerberos?"],"banners":[""]},"135":{"service_names":["epmap"],"banners":[""]},"139":{"service_names":["smb"],"banners":[""]},"389":{"service_names":["ldap"],"banners":[""]},"445":{"service_names":["cifs"],"banners":[""]},"464":{"service_names":["kpasswd?"],"banners":[""]},"593":{"service_names":["http-rpc-epmap"],"banners":[""]},"636":{"service_names":["ldap"],"banners":[""]},"3268":{"service_names":["ldap"],"banners":[""]},"3269":{"service_names":["ldap"],"banners":[""]},"3389":{"service_names":["msrdp"],"banners":[""]},"5985":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"5986":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"9389":{"service_names":[],"banners":[""]},"47001":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"49664":{"service_names":["dce-rpc"],"banners":[""]},"49665":{"service_names":["dce-rpc"],"banners":[""]},"49666":{"service_names":["dce-rpc"],"banners":[""]},"49667":{"service_names":["dce-rpc"],"banners":[""]},"49669":{"service_names":["dce-rpc"],"banners":[""]},"49670":{"service_names":["ncacn_http"],"banners":[""]},"49673":{"service_names":["dce-rpc"],"banners":[""]},"49676":{"service_names":["dce-rpc"],"banners":[""]},"49722":{"service_names":["dce-rpc"],"banners":[""]},"65363":{"service_names":["dce-rpc"],"banners":[""]},"65464":{"service_names":["dce-rpc"],"banners":[""]}},"udp_ports":{"53":{"service_names":["dns"],"banners":[""]},"123":{"service_names":["ntp"],"banners":[""]},"137":{"service_names":["netbios-ns"],"banners":[""]},"5355":{"service_names":["llmnr"],"banners":[""]}},"os":["windows"]},"192.168.56.22":{"hostnames":[],"tcp_ports":{"80":{"service_names":["www"],"banners":["Microsoft-IIS\/10.0"]},"135":{"service_names":["epmap"],"banners":[""]},"139":{"service_names":["smb"],"banners":[""]},"445":{"service_names":["cifs"],"banners":[""]},"1433":{"service_names":["mssql"],"banners":[""]},"3389":{"service_names":["msrdp"],"banners":[""]},"5985":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"5986":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"47001":{"service_names":["www"],"banners":["Microsoft-HTTPAPI\/2.0"]},"49664":{"service_names":["dce-rpc"],"banners":[""]},"49665":{"service_names":["dce-rpc"],"banners":[""]},"49666":{"service_names":["dce-rpc"],"banners":[""]},"49667":{"service_names":["dce-rpc"],"banners":[""]},"49668":{"service_names":["dce-rpc"],"banners":[""]},"49669":{"service_names":["dce-rpc"],"banners":[""]},"49682":{"service_names":["dce-rpc"],"banners":[""]},"49734":{"service_names":["dce-rpc"],"banners":[""]},"49813":{"service_names":["sybase"],"banners":[""]}},"udp_ports":{"137":{"service_names":["netbios-ns"],"banners":[""]},"5355":{"service_names":["llmnr"],"banners":[""]}},"os":["windows"]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w latex --multi-table]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.10} & \makecell[l]{} & \makecell[l]{windows} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.10} & \makecell[l]{} & \makecell[l]{windows} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{53/tcp} & \makecell[l]{dns} & \makecell[l]{} \\
+  \makecell[l]{53/udp} & \makecell[l]{dns} & \makecell[l]{} \\
+  \makecell[l]{80/tcp} & \makecell[l]{www} & \makecell[l]{Microsoft-IIS/10.0} \\
+  \makecell[l]{88/tcp} & \makecell[l]{kerberos?} & \makecell[l]{} \\
+  \makecell[l]{123/udp} & \makecell[l]{ntp} & \makecell[l]{} \\
+  \makecell[l]{135/tcp} & \makecell[l]{epmap} & \makecell[l]{} \\
+  \makecell[l]{137/udp} & \makecell[l]{netbios-ns} & \makecell[l]{} \\
+  \makecell[l]{139/tcp} & \makecell[l]{smb} & \makecell[l]{} \\
+  \makecell[l]{389/tcp} & \makecell[l]{ldap} & \makecell[l]{} \\
+  \makecell[l]{445/tcp} & \makecell[l]{cifs} & \makecell[l]{} \\
+  \makecell[l]{464/tcp} & \makecell[l]{kpasswd?} & \makecell[l]{} \\
+  \makecell[l]{593/tcp} & \makecell[l]{http-rpc-epmap} & \makecell[l]{} \\
+  \makecell[l]{636/tcp} & \makecell[l]{ldap} & \makecell[l]{} \\
+  \makecell[l]{3268/tcp} & \makecell[l]{ldap} & \makecell[l]{} \\
+  \makecell[l]{3269/tcp} & \makecell[l]{ldap} & \makecell[l]{} \\
+  \makecell[l]{3389/tcp} & \makecell[l]{msrdp} & \makecell[l]{} \\
+  \makecell[l]{5355/udp} & \makecell[l]{llmnr} & \makecell[l]{} \\
+  \makecell[l]{5985/tcp} & \makecell[l]{www} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \makecell[l]{5986/tcp} & \makecell[l]{www} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \makecell[l]{9389/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{47001/tcp} & \makecell[l]{www} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \makecell[l]{49664/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49665/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49666/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49667/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49669/tcp} & \makecell[l]{ncacn\_http} & \makecell[l]{} \\
+  \makecell[l]{49670/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49672/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49675/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49685/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49785/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49863/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49966/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \end{longtable}
+  
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.11} & \makecell[l]{} & \makecell[l]{windows} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.11} & \makecell[l]{} & \makecell[l]{windows} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{53/tcp} & \makecell[l]{dns} & \makecell[l]{} \\
+  \makecell[l]{53/udp} & \makecell[l]{dns} & \makecell[l]{} \\
+  \makecell[l]{88/tcp} & \makecell[l]{kerberos?} & \makecell[l]{} \\
+  \makecell[l]{123/udp} & \makecell[l]{ntp} & \makecell[l]{} \\
+  \makecell[l]{135/tcp} & \makecell[l]{epmap} & \makecell[l]{} \\
+  \makecell[l]{137/udp} & \makecell[l]{netbios-ns} & \makecell[l]{} \\
+  \makecell[l]{139/tcp} & \makecell[l]{smb} & \makecell[l]{} \\
+  \makecell[l]{389/tcp} & \makecell[l]{ldap} & \makecell[l]{} \\
+  \makecell[l]{445/tcp} & \makecell[l]{cifs} & \makecell[l]{} \\
+  \makecell[l]{464/tcp} & \makecell[l]{kpasswd?} & \makecell[l]{} \\
+  \makecell[l]{593/tcp} & \makecell[l]{http-rpc-epmap} & \makecell[l]{} \\
+  \makecell[l]{636/tcp} & \makecell[l]{ldap} & \makecell[l]{} \\
+  \makecell[l]{3268/tcp} & \makecell[l]{ldap} & \makecell[l]{} \\
+  \makecell[l]{3269/tcp} & \makecell[l]{ldap} & \makecell[l]{} \\
+  \makecell[l]{3389/tcp} & \makecell[l]{msrdp} & \makecell[l]{} \\
+  \makecell[l]{5355/udp} & \makecell[l]{llmnr} & \makecell[l]{} \\
+  \makecell[l]{5985/tcp} & \makecell[l]{www} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \makecell[l]{5986/tcp} & \makecell[l]{www} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \makecell[l]{9389/tcp} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{47001/tcp} & \makecell[l]{www} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \makecell[l]{49664/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49665/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49666/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49667/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49669/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49670/tcp} & \makecell[l]{ncacn\_http} & \makecell[l]{} \\
+  \makecell[l]{49673/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49676/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49722/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{65363/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{65464/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \end{longtable}
+  
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.22} & \makecell[l]{} & \makecell[l]{windows} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.22} & \makecell[l]{} & \makecell[l]{windows} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{80/tcp} & \makecell[l]{www} & \makecell[l]{Microsoft-IIS/10.0} \\
+  \makecell[l]{135/tcp} & \makecell[l]{epmap} & \makecell[l]{} \\
+  \makecell[l]{137/udp} & \makecell[l]{netbios-ns} & \makecell[l]{} \\
+  \makecell[l]{139/tcp} & \makecell[l]{smb} & \makecell[l]{} \\
+  \makecell[l]{445/tcp} & \makecell[l]{cifs} & \makecell[l]{} \\
+  \makecell[l]{1433/tcp} & \makecell[l]{mssql} & \makecell[l]{} \\
+  \makecell[l]{3389/tcp} & \makecell[l]{msrdp} & \makecell[l]{} \\
+  \makecell[l]{5355/udp} & \makecell[l]{llmnr} & \makecell[l]{} \\
+  \makecell[l]{5985/tcp} & \makecell[l]{www} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \makecell[l]{5986/tcp} & \makecell[l]{www} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \makecell[l]{47001/tcp} & \makecell[l]{www} & \makecell[l]{Microsoft-HTTPAPI/2.0} \\
+  \makecell[l]{49664/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49665/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49666/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49667/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49668/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49669/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49682/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49734/tcp} & \makecell[l]{dce-rpc} & \makecell[l]{} \\
+  \makecell[l]{49813/tcp} & \makecell[l]{sybase} & \makecell[l]{} \\
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w latex]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{llllll}
+  \caption{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{6}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{192.168.56.10} & \makecell[l]{} & \makecell[l]{53/tcp \\ 53/udp \\ 80/tcp \\ 88/tcp \\ 123/udp \\ 135/tcp \\ 137/udp \\ 139/tcp \\ 389/tcp \\ 445/tcp \\ 464/tcp \\ 593/tcp \\ 636/tcp \\ 3268/tcp \\ 3269/tcp \\ 3389/tcp \\ 5355/udp \\ 5985/tcp \\ 5986/tcp \\ 9389/tcp \\ 47001/tcp \\ 49664/tcp \\ 49665/tcp \\ 49666/tcp \\ 49667/tcp \\ 49669/tcp \\ 49670/tcp \\ 49672/tcp \\ 49675/tcp \\ 49685/tcp \\ 49785/tcp \\ 49863/tcp \\ 49966/tcp} & \makecell[l]{dns \\ dns \\ www \\ kerberos? \\ ntp \\ epmap \\ netbios-ns \\ smb \\ ldap \\ cifs \\ kpasswd? \\ http-rpc-epmap \\ ldap \\ ldap \\ ldap \\ msrdp \\ llmnr \\ www \\ www \\  \\ www \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ ncacn\_http \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc} & \makecell[l]{ \\  \\ Microsoft-IIS/10.0 \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\ Microsoft-HTTPAPI/2.0 \\ Microsoft-HTTPAPI/2.0 \\  \\ Microsoft-HTTPAPI/2.0 \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\ } & \makecell[l]{windows} \\
+  \makecell[l]{192.168.56.11} & \makecell[l]{} & \makecell[l]{53/tcp \\ 53/udp \\ 88/tcp \\ 123/udp \\ 135/tcp \\ 137/udp \\ 139/tcp \\ 389/tcp \\ 445/tcp \\ 464/tcp \\ 593/tcp \\ 636/tcp \\ 3268/tcp \\ 3269/tcp \\ 3389/tcp \\ 5355/udp \\ 5985/tcp \\ 5986/tcp \\ 9389/tcp \\ 47001/tcp \\ 49664/tcp \\ 49665/tcp \\ 49666/tcp \\ 49667/tcp \\ 49669/tcp \\ 49670/tcp \\ 49673/tcp \\ 49676/tcp \\ 49722/tcp \\ 65363/tcp \\ 65464/tcp} & \makecell[l]{dns \\ dns \\ kerberos? \\ ntp \\ epmap \\ netbios-ns \\ smb \\ ldap \\ cifs \\ kpasswd? \\ http-rpc-epmap \\ ldap \\ ldap \\ ldap \\ msrdp \\ llmnr \\ www \\ www \\  \\ www \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ ncacn\_http \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc} & \makecell[l]{ \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\ Microsoft-HTTPAPI/2.0 \\ Microsoft-HTTPAPI/2.0 \\  \\ Microsoft-HTTPAPI/2.0 \\  \\  \\  \\  \\  \\  \\  \\  \\  \\  \\ } & \makecell[l]{windows} \\
+  \makecell[l]{192.168.56.22} & \makecell[l]{} & \makecell[l]{80/tcp \\ 135/tcp \\ 137/udp \\ 139/tcp \\ 445/tcp \\ 1433/tcp \\ 3389/tcp \\ 5355/udp \\ 5985/tcp \\ 5986/tcp \\ 47001/tcp \\ 49664/tcp \\ 49665/tcp \\ 49666/tcp \\ 49667/tcp \\ 49668/tcp \\ 49669/tcp \\ 49682/tcp \\ 49734/tcp \\ 49813/tcp} & \makecell[l]{www \\ epmap \\ netbios-ns \\ smb \\ cifs \\ mssql \\ msrdp \\ llmnr \\ www \\ www \\ www \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ dce-rpc \\ sybase} & \makecell[l]{Microsoft-IIS/10.0 \\  \\  \\  \\  \\  \\  \\  \\ Microsoft-HTTPAPI/2.0 \\ Microsoft-HTTPAPI/2.0 \\ Microsoft-HTTPAPI/2.0 \\  \\  \\  \\  \\  \\  \\  \\  \\ } & \makecell[l]{windows} \\
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w markdown --multi-table]
+  '''
+  | 192.168.56.10   |                | windows               |
+  |:----------------|:---------------|:----------------------|
+  | 53/tcp          | dns            |                       |
+  | 53/udp          | dns            |                       |
+  | 80/tcp          | www            | Microsoft-IIS/10.0    |
+  | 88/tcp          | kerberos?      |                       |
+  | 123/udp         | ntp            |                       |
+  | 135/tcp         | epmap          |                       |
+  | 137/udp         | netbios-ns     |                       |
+  | 139/tcp         | smb            |                       |
+  | 389/tcp         | ldap           |                       |
+  | 445/tcp         | cifs           |                       |
+  | 464/tcp         | kpasswd?       |                       |
+  | 593/tcp         | http-rpc-epmap |                       |
+  | 636/tcp         | ldap           |                       |
+  | 3268/tcp        | ldap           |                       |
+  | 3269/tcp        | ldap           |                       |
+  | 3389/tcp        | msrdp          |                       |
+  | 5355/udp        | llmnr          |                       |
+  | 5985/tcp        | www            | Microsoft-HTTPAPI/2.0 |
+  | 5986/tcp        | www            | Microsoft-HTTPAPI/2.0 |
+  | 9389/tcp        |                |                       |
+  | 47001/tcp       | www            | Microsoft-HTTPAPI/2.0 |
+  | 49664/tcp       | dce-rpc        |                       |
+  | 49665/tcp       | dce-rpc        |                       |
+  | 49666/tcp       | dce-rpc        |                       |
+  | 49667/tcp       | dce-rpc        |                       |
+  | 49669/tcp       | ncacn\_http    |                       |
+  | 49670/tcp       | dce-rpc        |                       |
+  | 49672/tcp       | dce-rpc        |                       |
+  | 49675/tcp       | dce-rpc        |                       |
+  | 49685/tcp       | dce-rpc        |                       |
+  | 49785/tcp       | dce-rpc        |                       |
+  | 49863/tcp       | dce-rpc        |                       |
+  | 49966/tcp       | dce-rpc        |                       |
+  
+  
+  | 192.168.56.11   |                | windows               |
+  |:----------------|:---------------|:----------------------|
+  | 53/tcp          | dns            |                       |
+  | 53/udp          | dns            |                       |
+  | 88/tcp          | kerberos?      |                       |
+  | 123/udp         | ntp            |                       |
+  | 135/tcp         | epmap          |                       |
+  | 137/udp         | netbios-ns     |                       |
+  | 139/tcp         | smb            |                       |
+  | 389/tcp         | ldap           |                       |
+  | 445/tcp         | cifs           |                       |
+  | 464/tcp         | kpasswd?       |                       |
+  | 593/tcp         | http-rpc-epmap |                       |
+  | 636/tcp         | ldap           |                       |
+  | 3268/tcp        | ldap           |                       |
+  | 3269/tcp        | ldap           |                       |
+  | 3389/tcp        | msrdp          |                       |
+  | 5355/udp        | llmnr          |                       |
+  | 5985/tcp        | www            | Microsoft-HTTPAPI/2.0 |
+  | 5986/tcp        | www            | Microsoft-HTTPAPI/2.0 |
+  | 9389/tcp        |                |                       |
+  | 47001/tcp       | www            | Microsoft-HTTPAPI/2.0 |
+  | 49664/tcp       | dce-rpc        |                       |
+  | 49665/tcp       | dce-rpc        |                       |
+  | 49666/tcp       | dce-rpc        |                       |
+  | 49667/tcp       | dce-rpc        |                       |
+  | 49669/tcp       | dce-rpc        |                       |
+  | 49670/tcp       | ncacn\_http    |                       |
+  | 49673/tcp       | dce-rpc        |                       |
+  | 49676/tcp       | dce-rpc        |                       |
+  | 49722/tcp       | dce-rpc        |                       |
+  | 65363/tcp       | dce-rpc        |                       |
+  | 65464/tcp       | dce-rpc        |                       |
+  
+  
+  | 192.168.56.22   |            | windows               |
+  |:----------------|:-----------|:----------------------|
+  | 80/tcp          | www        | Microsoft-IIS/10.0    |
+  | 135/tcp         | epmap      |                       |
+  | 137/udp         | netbios-ns |                       |
+  | 139/tcp         | smb        |                       |
+  | 445/tcp         | cifs       |                       |
+  | 1433/tcp        | mssql      |                       |
+  | 3389/tcp        | msrdp      |                       |
+  | 5355/udp        | llmnr      |                       |
+  | 5985/tcp        | www        | Microsoft-HTTPAPI/2.0 |
+  | 5986/tcp        | www        | Microsoft-HTTPAPI/2.0 |
+  | 47001/tcp       | www        | Microsoft-HTTPAPI/2.0 |
+  | 49664/tcp       | dce-rpc    |                       |
+  | 49665/tcp       | dce-rpc    |                       |
+  | 49666/tcp       | dce-rpc    |                       |
+  | 49667/tcp       | dce-rpc    |                       |
+  | 49668/tcp       | dce-rpc    |                       |
+  | 49669/tcp       | dce-rpc    |                       |
+  | 49682/tcp       | dce-rpc    |                       |
+  | 49734/tcp       | dce-rpc    |                       |
+  | 49813/tcp       | sybase     |                       |
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w markdown]
+  '''
+  | IP-Addresses   | Hostnames   | Ports                                                                                                                                                                                                                                                                                                                                                                                                | Services                                                                                                                                                                                                                                                                                                                     | Banners                                                                                                                                                                                                           | OS      |
+  |:---------------|:------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------|
+  | 192.168.56.10  |             | 53/tcp<br>53/udp<br>80/tcp<br>88/tcp<br>123/udp<br>135/tcp<br>137/udp<br>139/tcp<br>389/tcp<br>445/tcp<br>464/tcp<br>593/tcp<br>636/tcp<br>3268/tcp<br>3269/tcp<br>3389/tcp<br>5355/udp<br>5985/tcp<br>5986/tcp<br>9389/tcp<br>47001/tcp<br>49664/tcp<br>49665/tcp<br>49666/tcp<br>49667/tcp<br>49669/tcp<br>49670/tcp<br>49672/tcp<br>49675/tcp<br>49685/tcp<br>49785/tcp<br>49863/tcp<br>49966/tcp | dns<br>dns<br>www<br>kerberos?<br>ntp<br>epmap<br>netbios-ns<br>smb<br>ldap<br>cifs<br>kpasswd?<br>http-rpc-epmap<br>ldap<br>ldap<br>ldap<br>msrdp<br>llmnr<br>www<br>www<br><br>www<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>ncacn\_http<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc | <br><br>Microsoft-IIS/10.0<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0<br><br>Microsoft-HTTPAPI/2.0<br><br><br><br><br><br><br><br><br><br><br><br> | windows |
+  | 192.168.56.11  |             | 53/tcp<br>53/udp<br>88/tcp<br>123/udp<br>135/tcp<br>137/udp<br>139/tcp<br>389/tcp<br>445/tcp<br>464/tcp<br>593/tcp<br>636/tcp<br>3268/tcp<br>3269/tcp<br>3389/tcp<br>5355/udp<br>5985/tcp<br>5986/tcp<br>9389/tcp<br>47001/tcp<br>49664/tcp<br>49665/tcp<br>49666/tcp<br>49667/tcp<br>49669/tcp<br>49670/tcp<br>49673/tcp<br>49676/tcp<br>49722/tcp<br>65363/tcp<br>65464/tcp                        | dns<br>dns<br>kerberos?<br>ntp<br>epmap<br>netbios-ns<br>smb<br>ldap<br>cifs<br>kpasswd?<br>http-rpc-epmap<br>ldap<br>ldap<br>ldap<br>msrdp<br>llmnr<br>www<br>www<br><br>www<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>ncacn\_http<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc                   | <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0<br><br>Microsoft-HTTPAPI/2.0<br><br><br><br><br><br><br><br><br><br><br>                           | windows |
+  | 192.168.56.22  |             | 80/tcp<br>135/tcp<br>137/udp<br>139/tcp<br>445/tcp<br>1433/tcp<br>3389/tcp<br>5355/udp<br>5985/tcp<br>5986/tcp<br>47001/tcp<br>49664/tcp<br>49665/tcp<br>49666/tcp<br>49667/tcp<br>49668/tcp<br>49669/tcp<br>49682/tcp<br>49734/tcp<br>49813/tcp                                                                                                                                                     | www<br>epmap<br>netbios-ns<br>smb<br>cifs<br>mssql<br>msrdp<br>llmnr<br>www<br>www<br>www<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>dce-rpc<br>sybase                                                                                                                                  | Microsoft-IIS/10.0<br><br><br><br><br><br><br><br>Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0<br>Microsoft-HTTPAPI/2.0<br><br><br><br><br><br><br><br><br>                                                     | windows |
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w nmap --multi-table]
+  '''
+  #!/bin/sh
+  
+  nmap 192.168.56.10 -sS -A -Pn -n -T4 -oA 192.168.56.10 -p 53,80,88,135,139,389,445,464,593,636,3268,3269,3389,5985,5986,9389,47001,49664,49665,49666,49667,49669,49670,49672,49675,49685,49785,49863,49966,49967
+  nmap 192.168.56.10 -sU -A -Pn -n -T4 -oA 192.168.56.10u -p 53,123,137,5355
+  nmap 192.168.56.11 -sS -A -Pn -n -T4 -oA 192.168.56.11 -p 53,88,135,139,389,445,464,593,636,3268,3269,3389,5985,5986,9389,47001,49664,49665,49666,49667,49669,49670,49673,49676,49722,65363,65464,65465
+  nmap 192.168.56.11 -sU -A -Pn -n -T4 -oA 192.168.56.11u -p 53,123,137,5355
+  nmap 192.168.56.22 -sS -A -Pn -n -T4 -oA 192.168.56.22 -p 80,135,139,445,1433,3389,5985,5986,47001,49664,49665,49666,49667,49668,49669,49682,49734,49813,49814
+  nmap 192.168.56.22 -sU -A -Pn -n -T4 -oA 192.168.56.22u -p 137,5355
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w nmap]
+  '''
+  #!/bin/sh
+  
+  nmap 192.168.56.10 -sS -A -Pn -n -T4 -oA 192.168.56.10 -p 53,80,88,135,139,389,445,464,593,636,3268,3269,3389,5985,5986,9389,47001,49664,49665,49666,49667,49669,49670,49672,49675,49685,49785,49863,49966,49967
+  nmap 192.168.56.10 -sU -A -Pn -n -T4 -oA 192.168.56.10u -p 53,123,137,5355
+  nmap 192.168.56.11 -sS -A -Pn -n -T4 -oA 192.168.56.11 -p 53,88,135,139,389,445,464,593,636,3268,3269,3389,5985,5986,9389,47001,49664,49665,49666,49667,49669,49670,49673,49676,49722,65363,65464,65465
+  nmap 192.168.56.11 -sU -A -Pn -n -T4 -oA 192.168.56.11u -p 53,123,137,5355
+  nmap 192.168.56.22 -sS -A -Pn -n -T4 -oA 192.168.56.22 -p 80,135,139,445,1433,3389,5985,5986,47001,49664,49665,49666,49667,49668,49669,49682,49734,49813,49814
+  nmap 192.168.56.22 -sU -A -Pn -n -T4 -oA 192.168.56.22u -p 137,5355
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w terminal --multi-table]
+  '''
+  ╒═════════════════╤════════════════╤═══════════════════════╕
+  │ 192.168.56.10   │                │ windows               │
+  ╞═════════════════╪════════════════╪═══════════════════════╡
+  │ 53/tcp          │ dns            │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 53/udp          │ dns            │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 80/tcp          │ www            │ Microsoft-IIS/10.0    │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 88/tcp          │ kerberos?      │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 123/udp         │ ntp            │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 135/tcp         │ epmap          │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 137/udp         │ netbios-ns     │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 139/tcp         │ smb            │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 389/tcp         │ ldap           │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 445/tcp         │ cifs           │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 464/tcp         │ kpasswd?       │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 593/tcp         │ http-rpc-epmap │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 636/tcp         │ ldap           │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 3268/tcp        │ ldap           │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 3269/tcp        │ ldap           │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 3389/tcp        │ msrdp          │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 5355/udp        │ llmnr          │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 5985/tcp        │ www            │ Microsoft-HTTPAPI/2.0 │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 5986/tcp        │ www            │ Microsoft-HTTPAPI/2.0 │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 9389/tcp        │                │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 47001/tcp       │ www            │ Microsoft-HTTPAPI/2.0 │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49664/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49665/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49666/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49667/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49669/tcp       │ ncacn_http     │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49670/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49672/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49675/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49685/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49785/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49863/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49966/tcp       │ dce-rpc        │                       │
+  ╘═════════════════╧════════════════╧═══════════════════════╛
+  
+  ╒═════════════════╤════════════════╤═══════════════════════╕
+  │ 192.168.56.11   │                │ windows               │
+  ╞═════════════════╪════════════════╪═══════════════════════╡
+  │ 53/tcp          │ dns            │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 53/udp          │ dns            │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 88/tcp          │ kerberos?      │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 123/udp         │ ntp            │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 135/tcp         │ epmap          │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 137/udp         │ netbios-ns     │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 139/tcp         │ smb            │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 389/tcp         │ ldap           │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 445/tcp         │ cifs           │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 464/tcp         │ kpasswd?       │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 593/tcp         │ http-rpc-epmap │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 636/tcp         │ ldap           │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 3268/tcp        │ ldap           │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 3269/tcp        │ ldap           │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 3389/tcp        │ msrdp          │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 5355/udp        │ llmnr          │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 5985/tcp        │ www            │ Microsoft-HTTPAPI/2.0 │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 5986/tcp        │ www            │ Microsoft-HTTPAPI/2.0 │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 9389/tcp        │                │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 47001/tcp       │ www            │ Microsoft-HTTPAPI/2.0 │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49664/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49665/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49666/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49667/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49669/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49670/tcp       │ ncacn_http     │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49673/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49676/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 49722/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 65363/tcp       │ dce-rpc        │                       │
+  ├─────────────────┼────────────────┼───────────────────────┤
+  │ 65464/tcp       │ dce-rpc        │                       │
+  ╘═════════════════╧════════════════╧═══════════════════════╛
+  
+  ╒═════════════════╤════════════╤═══════════════════════╕
+  │ 192.168.56.22   │            │ windows               │
+  ╞═════════════════╪════════════╪═══════════════════════╡
+  │ 80/tcp          │ www        │ Microsoft-IIS/10.0    │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 135/tcp         │ epmap      │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 137/udp         │ netbios-ns │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 139/tcp         │ smb        │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 445/tcp         │ cifs       │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 1433/tcp        │ mssql      │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 3389/tcp        │ msrdp      │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 5355/udp        │ llmnr      │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 5985/tcp        │ www        │ Microsoft-HTTPAPI/2.0 │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 5986/tcp        │ www        │ Microsoft-HTTPAPI/2.0 │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 47001/tcp       │ www        │ Microsoft-HTTPAPI/2.0 │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 49664/tcp       │ dce-rpc    │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 49665/tcp       │ dce-rpc    │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 49666/tcp       │ dce-rpc    │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 49667/tcp       │ dce-rpc    │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 49668/tcp       │ dce-rpc    │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 49669/tcp       │ dce-rpc    │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 49682/tcp       │ dce-rpc    │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 49734/tcp       │ dce-rpc    │                       │
+  ├─────────────────┼────────────┼───────────────────────┤
+  │ 49813/tcp       │ sybase     │                       │
+  ╘═════════════════╧════════════╧═══════════════════════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w terminal]
+  '''
+  ╒════════════════╤═════════════╤═══════════╤════════════════╤═══════════════════════╤═════════╕
+  │ IP-Addresses   │ Hostnames   │ Ports     │ Services       │ Banners               │ OS      │
+  ╞════════════════╪═════════════╪═══════════╪════════════════╪═══════════════════════╪═════════╡
+  │ 192.168.56.10  │             │ 53/tcp    │ dns            │                       │ windows │
+  │                │             │ 53/udp    │ dns            │                       │         │
+  │                │             │ 80/tcp    │ www            │ Microsoft-IIS/10.0    │         │
+  │                │             │ 88/tcp    │ kerberos?      │                       │         │
+  │                │             │ 123/udp   │ ntp            │                       │         │
+  │                │             │ 135/tcp   │ epmap          │                       │         │
+  │                │             │ 137/udp   │ netbios-ns     │                       │         │
+  │                │             │ 139/tcp   │ smb            │                       │         │
+  │                │             │ 389/tcp   │ ldap           │                       │         │
+  │                │             │ 445/tcp   │ cifs           │                       │         │
+  │                │             │ 464/tcp   │ kpasswd?       │                       │         │
+  │                │             │ 593/tcp   │ http-rpc-epmap │                       │         │
+  │                │             │ 636/tcp   │ ldap           │                       │         │
+  │                │             │ 3268/tcp  │ ldap           │                       │         │
+  │                │             │ 3269/tcp  │ ldap           │                       │         │
+  │                │             │ 3389/tcp  │ msrdp          │                       │         │
+  │                │             │ 5355/udp  │ llmnr          │                       │         │
+  │                │             │ 5985/tcp  │ www            │ Microsoft-HTTPAPI/2.0 │         │
+  │                │             │ 5986/tcp  │ www            │ Microsoft-HTTPAPI/2.0 │         │
+  │                │             │ 9389/tcp  │                │                       │         │
+  │                │             │ 47001/tcp │ www            │ Microsoft-HTTPAPI/2.0 │         │
+  │                │             │ 49664/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49665/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49666/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49667/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49669/tcp │ ncacn_http     │                       │         │
+  │                │             │ 49670/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49672/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49675/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49685/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49785/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49863/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49966/tcp │ dce-rpc        │                       │         │
+  ├────────────────┼─────────────┼───────────┼────────────────┼───────────────────────┼─────────┤
+  │ 192.168.56.11  │             │ 53/tcp    │ dns            │                       │ windows │
+  │                │             │ 53/udp    │ dns            │                       │         │
+  │                │             │ 88/tcp    │ kerberos?      │                       │         │
+  │                │             │ 123/udp   │ ntp            │                       │         │
+  │                │             │ 135/tcp   │ epmap          │                       │         │
+  │                │             │ 137/udp   │ netbios-ns     │                       │         │
+  │                │             │ 139/tcp   │ smb            │                       │         │
+  │                │             │ 389/tcp   │ ldap           │                       │         │
+  │                │             │ 445/tcp   │ cifs           │                       │         │
+  │                │             │ 464/tcp   │ kpasswd?       │                       │         │
+  │                │             │ 593/tcp   │ http-rpc-epmap │                       │         │
+  │                │             │ 636/tcp   │ ldap           │                       │         │
+  │                │             │ 3268/tcp  │ ldap           │                       │         │
+  │                │             │ 3269/tcp  │ ldap           │                       │         │
+  │                │             │ 3389/tcp  │ msrdp          │                       │         │
+  │                │             │ 5355/udp  │ llmnr          │                       │         │
+  │                │             │ 5985/tcp  │ www            │ Microsoft-HTTPAPI/2.0 │         │
+  │                │             │ 5986/tcp  │ www            │ Microsoft-HTTPAPI/2.0 │         │
+  │                │             │ 9389/tcp  │                │                       │         │
+  │                │             │ 47001/tcp │ www            │ Microsoft-HTTPAPI/2.0 │         │
+  │                │             │ 49664/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49665/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49666/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49667/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49669/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49670/tcp │ ncacn_http     │                       │         │
+  │                │             │ 49673/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49676/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49722/tcp │ dce-rpc        │                       │         │
+  │                │             │ 65363/tcp │ dce-rpc        │                       │         │
+  │                │             │ 65464/tcp │ dce-rpc        │                       │         │
+  ├────────────────┼─────────────┼───────────┼────────────────┼───────────────────────┼─────────┤
+  │ 192.168.56.22  │             │ 80/tcp    │ www            │ Microsoft-IIS/10.0    │ windows │
+  │                │             │ 135/tcp   │ epmap          │                       │         │
+  │                │             │ 137/udp   │ netbios-ns     │                       │         │
+  │                │             │ 139/tcp   │ smb            │                       │         │
+  │                │             │ 445/tcp   │ cifs           │                       │         │
+  │                │             │ 1433/tcp  │ mssql          │                       │         │
+  │                │             │ 3389/tcp  │ msrdp          │                       │         │
+  │                │             │ 5355/udp  │ llmnr          │                       │         │
+  │                │             │ 5985/tcp  │ www            │ Microsoft-HTTPAPI/2.0 │         │
+  │                │             │ 5986/tcp  │ www            │ Microsoft-HTTPAPI/2.0 │         │
+  │                │             │ 47001/tcp │ www            │ Microsoft-HTTPAPI/2.0 │         │
+  │                │             │ 49664/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49665/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49666/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49667/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49668/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49669/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49682/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49734/tcp │ dce-rpc        │                       │         │
+  │                │             │ 49813/tcp │ sybase         │                       │         │
+  ╘════════════════╧═════════════╧═══════════╧════════════════╧═══════════════════════╧═════════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w typst --multi-table]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (3),
+    [*192.168.56.10*], [**], [*windows*],
+    [53/tcp], [dns], [],
+    [53/udp], [dns], [],
+    [80/tcp], [www], [Microsoft-IIS/10.0],
+    [88/tcp], [kerberos?], [],
+    [123/udp], [ntp], [],
+    [135/tcp], [epmap], [],
+    [137/udp], [netbios-ns], [],
+    [139/tcp], [smb], [],
+    [389/tcp], [ldap], [],
+    [445/tcp], [cifs], [],
+    [464/tcp], [kpasswd?], [],
+    [593/tcp], [http-rpc-epmap], [],
+    [636/tcp], [ldap], [],
+    [3268/tcp], [ldap], [],
+    [3269/tcp], [ldap], [],
+    [3389/tcp], [msrdp], [],
+    [5355/udp], [llmnr], [],
+    [5985/tcp], [www], [Microsoft-HTTPAPI/2.0],
+    [5986/tcp], [www], [Microsoft-HTTPAPI/2.0],
+    [9389/tcp], [], [],
+    [47001/tcp], [www], [Microsoft-HTTPAPI/2.0],
+    [49664/tcp], [dce-rpc], [],
+    [49665/tcp], [dce-rpc], [],
+    [49666/tcp], [dce-rpc], [],
+    [49667/tcp], [dce-rpc], [],
+    [49669/tcp], [ncacn\_http], [],
+    [49670/tcp], [dce-rpc], [],
+    [49672/tcp], [dce-rpc], [],
+    [49675/tcp], [dce-rpc], [],
+    [49685/tcp], [dce-rpc], [],
+    [49785/tcp], [dce-rpc], [],
+    [49863/tcp], [dce-rpc], [],
+    [49966/tcp], [dce-rpc], []
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [*192.168.56.11*], [**], [*windows*],
+    [53/tcp], [dns], [],
+    [53/udp], [dns], [],
+    [88/tcp], [kerberos?], [],
+    [123/udp], [ntp], [],
+    [135/tcp], [epmap], [],
+    [137/udp], [netbios-ns], [],
+    [139/tcp], [smb], [],
+    [389/tcp], [ldap], [],
+    [445/tcp], [cifs], [],
+    [464/tcp], [kpasswd?], [],
+    [593/tcp], [http-rpc-epmap], [],
+    [636/tcp], [ldap], [],
+    [3268/tcp], [ldap], [],
+    [3269/tcp], [ldap], [],
+    [3389/tcp], [msrdp], [],
+    [5355/udp], [llmnr], [],
+    [5985/tcp], [www], [Microsoft-HTTPAPI/2.0],
+    [5986/tcp], [www], [Microsoft-HTTPAPI/2.0],
+    [9389/tcp], [], [],
+    [47001/tcp], [www], [Microsoft-HTTPAPI/2.0],
+    [49664/tcp], [dce-rpc], [],
+    [49665/tcp], [dce-rpc], [],
+    [49666/tcp], [dce-rpc], [],
+    [49667/tcp], [dce-rpc], [],
+    [49669/tcp], [dce-rpc], [],
+    [49670/tcp], [ncacn\_http], [],
+    [49673/tcp], [dce-rpc], [],
+    [49676/tcp], [dce-rpc], [],
+    [49722/tcp], [dce-rpc], [],
+    [65363/tcp], [dce-rpc], [],
+    [65464/tcp], [dce-rpc], []
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [*192.168.56.22*], [**], [*windows*],
+    [80/tcp], [www], [Microsoft-IIS/10.0],
+    [135/tcp], [epmap], [],
+    [137/udp], [netbios-ns], [],
+    [139/tcp], [smb], [],
+    [445/tcp], [cifs], [],
+    [1433/tcp], [mssql], [],
+    [3389/tcp], [msrdp], [],
+    [5355/udp], [llmnr], [],
+    [5985/tcp], [www], [Microsoft-HTTPAPI/2.0],
+    [5986/tcp], [www], [Microsoft-HTTPAPI/2.0],
+    [47001/tcp], [www], [Microsoft-HTTPAPI/2.0],
+    [49664/tcp], [dce-rpc], [],
+    [49665/tcp], [dce-rpc], [],
+    [49666/tcp], [dce-rpc], [],
+    [49667/tcp], [dce-rpc], [],
+    [49668/tcp], [dce-rpc], [],
+    [49669/tcp], [dce-rpc], [],
+    [49682/tcp], [dce-rpc], [],
+    [49734/tcp], [dce-rpc], [],
+    [49813/tcp], [sybase], []
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w typst]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (6),
+    [*IP-Addresses*], [*Hostnames*], [*Ports*], [*Services*], [*Banners*], [*OS*],
+    [192.168.56.10], [], [53/tcp \ 53/udp \ 80/tcp \ 88/tcp \ 123/udp \ 135/tcp \ 137/udp \ 139/tcp \ 389/tcp \ 445/tcp \ 464/tcp \ 593/tcp \ 636/tcp \ 3268/tcp \ 3269/tcp \ 3389/tcp \ 5355/udp \ 5985/tcp \ 5986/tcp \ 9389/tcp \ 47001/tcp \ 49664/tcp \ 49665/tcp \ 49666/tcp \ 49667/tcp \ 49669/tcp \ 49670/tcp \ 49672/tcp \ 49675/tcp \ 49685/tcp \ 49785/tcp \ 49863/tcp \ 49966/tcp], [dns \ dns \ www \ kerberos? \ ntp \ epmap \ netbios-ns \ smb \ ldap \ cifs \ kpasswd? \ http-rpc-epmap \ ldap \ ldap \ ldap \ msrdp \ llmnr \ www \ www \  \ www \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc \ ncacn\_http \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc], [ \  \ Microsoft-IIS/10.0 \  \  \  \  \  \  \  \  \  \  \  \  \  \  \ Microsoft-HTTPAPI/2.0 \ Microsoft-HTTPAPI/2.0 \  \ Microsoft-HTTPAPI/2.0 \  \  \  \  \  \  \  \  \  \  \  \ ], [windows],
+    [192.168.56.11], [], [53/tcp \ 53/udp \ 88/tcp \ 123/udp \ 135/tcp \ 137/udp \ 139/tcp \ 389/tcp \ 445/tcp \ 464/tcp \ 593/tcp \ 636/tcp \ 3268/tcp \ 3269/tcp \ 3389/tcp \ 5355/udp \ 5985/tcp \ 5986/tcp \ 9389/tcp \ 47001/tcp \ 49664/tcp \ 49665/tcp \ 49666/tcp \ 49667/tcp \ 49669/tcp \ 49670/tcp \ 49673/tcp \ 49676/tcp \ 49722/tcp \ 65363/tcp \ 65464/tcp], [dns \ dns \ kerberos? \ ntp \ epmap \ netbios-ns \ smb \ ldap \ cifs \ kpasswd? \ http-rpc-epmap \ ldap \ ldap \ ldap \ msrdp \ llmnr \ www \ www \  \ www \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc \ ncacn\_http \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc], [ \  \  \  \  \  \  \  \  \  \  \  \  \  \  \  \ Microsoft-HTTPAPI/2.0 \ Microsoft-HTTPAPI/2.0 \  \ Microsoft-HTTPAPI/2.0 \  \  \  \  \  \  \  \  \  \  \ ], [windows],
+    [192.168.56.22], [], [80/tcp \ 135/tcp \ 137/udp \ 139/tcp \ 445/tcp \ 1433/tcp \ 3389/tcp \ 5355/udp \ 5985/tcp \ 5986/tcp \ 47001/tcp \ 49664/tcp \ 49665/tcp \ 49666/tcp \ 49667/tcp \ 49668/tcp \ 49669/tcp \ 49682/tcp \ 49734/tcp \ 49813/tcp], [www \ epmap \ netbios-ns \ smb \ cifs \ mssql \ msrdp \ llmnr \ www \ www \ www \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc \ dce-rpc \ sybase], [Microsoft-IIS/10.0 \  \  \  \  \  \  \  \ Microsoft-HTTPAPI/2.0 \ Microsoft-HTTPAPI/2.0 \ Microsoft-HTTPAPI/2.0 \  \  \  \  \  \  \  \  \ ], [windows]
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w url --multi-table]
+  '''
+  cifs://192.168.56.10:445
+  cifs://192.168.56.11:445
+  cifs://192.168.56.22:445
+  dce-rpc://192.168.56.10:49664
+  dce-rpc://192.168.56.10:49665
+  dce-rpc://192.168.56.10:49666
+  dce-rpc://192.168.56.10:49667
+  dce-rpc://192.168.56.10:49670
+  dce-rpc://192.168.56.10:49672
+  dce-rpc://192.168.56.10:49675
+  dce-rpc://192.168.56.10:49685
+  dce-rpc://192.168.56.10:49785
+  dce-rpc://192.168.56.10:49863
+  dce-rpc://192.168.56.10:49966
+  dce-rpc://192.168.56.11:49664
+  dce-rpc://192.168.56.11:49665
+  dce-rpc://192.168.56.11:49666
+  dce-rpc://192.168.56.11:49667
+  dce-rpc://192.168.56.11:49669
+  dce-rpc://192.168.56.11:49673
+  dce-rpc://192.168.56.11:49676
+  dce-rpc://192.168.56.11:49722
+  dce-rpc://192.168.56.11:65363
+  dce-rpc://192.168.56.11:65464
+  dce-rpc://192.168.56.22:49664
+  dce-rpc://192.168.56.22:49665
+  dce-rpc://192.168.56.22:49666
+  dce-rpc://192.168.56.22:49667
+  dce-rpc://192.168.56.22:49668
+  dce-rpc://192.168.56.22:49669
+  dce-rpc://192.168.56.22:49682
+  dce-rpc://192.168.56.22:49734
+  dns://192.168.56.10:53
+  dns://192.168.56.11:53
+  epmap://192.168.56.10:135
+  epmap://192.168.56.11:135
+  epmap://192.168.56.22:135
+  http-rpc-epmap://192.168.56.10:593
+  http-rpc-epmap://192.168.56.11:593
+  kerberos?://192.168.56.10:88
+  kerberos?://192.168.56.11:88
+  kpasswd?://192.168.56.10:464
+  kpasswd?://192.168.56.11:464
+  ldap://192.168.56.10:3268
+  ldap://192.168.56.10:3269
+  ldap://192.168.56.10:389
+  ldap://192.168.56.10:636
+  ldap://192.168.56.11:3268
+  ldap://192.168.56.11:3269
+  ldap://192.168.56.11:389
+  ldap://192.168.56.11:636
+  llmnr://192.168.56.10:5355
+  llmnr://192.168.56.11:5355
+  llmnr://192.168.56.22:5355
+  msrdp://192.168.56.10:3389
+  msrdp://192.168.56.11:3389
+  msrdp://192.168.56.22:3389
+  mssql://192.168.56.22:1433
+  ncacn_http://192.168.56.10:49669
+  ncacn_http://192.168.56.11:49670
+  netbios-ns://192.168.56.10:137
+  netbios-ns://192.168.56.11:137
+  netbios-ns://192.168.56.22:137
+  ntp://192.168.56.10:123
+  ntp://192.168.56.11:123
+  smb://192.168.56.10:139
+  smb://192.168.56.11:139
+  smb://192.168.56.22:139
+  sybase://192.168.56.22:49813
+  unknown://192.168.56.10:9389
+  unknown://192.168.56.11:9389
+  www://192.168.56.10:47001
+  www://192.168.56.10:5985
+  www://192.168.56.10:5986
+  www://192.168.56.10:80
+  www://192.168.56.11:47001
+  www://192.168.56.11:5985
+  www://192.168.56.11:5986
+  www://192.168.56.22:47001
+  www://192.168.56.22:5985
+  www://192.168.56.22:5986
+  www://192.168.56.22:80
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w url]
+  '''
+  cifs://192.168.56.10:445
+  cifs://192.168.56.11:445
+  cifs://192.168.56.22:445
+  dce-rpc://192.168.56.10:49664
+  dce-rpc://192.168.56.10:49665
+  dce-rpc://192.168.56.10:49666
+  dce-rpc://192.168.56.10:49667
+  dce-rpc://192.168.56.10:49670
+  dce-rpc://192.168.56.10:49672
+  dce-rpc://192.168.56.10:49675
+  dce-rpc://192.168.56.10:49685
+  dce-rpc://192.168.56.10:49785
+  dce-rpc://192.168.56.10:49863
+  dce-rpc://192.168.56.10:49966
+  dce-rpc://192.168.56.11:49664
+  dce-rpc://192.168.56.11:49665
+  dce-rpc://192.168.56.11:49666
+  dce-rpc://192.168.56.11:49667
+  dce-rpc://192.168.56.11:49669
+  dce-rpc://192.168.56.11:49673
+  dce-rpc://192.168.56.11:49676
+  dce-rpc://192.168.56.11:49722
+  dce-rpc://192.168.56.11:65363
+  dce-rpc://192.168.56.11:65464
+  dce-rpc://192.168.56.22:49664
+  dce-rpc://192.168.56.22:49665
+  dce-rpc://192.168.56.22:49666
+  dce-rpc://192.168.56.22:49667
+  dce-rpc://192.168.56.22:49668
+  dce-rpc://192.168.56.22:49669
+  dce-rpc://192.168.56.22:49682
+  dce-rpc://192.168.56.22:49734
+  dns://192.168.56.10:53
+  dns://192.168.56.11:53
+  epmap://192.168.56.10:135
+  epmap://192.168.56.11:135
+  epmap://192.168.56.22:135
+  http-rpc-epmap://192.168.56.10:593
+  http-rpc-epmap://192.168.56.11:593
+  kerberos?://192.168.56.10:88
+  kerberos?://192.168.56.11:88
+  kpasswd?://192.168.56.10:464
+  kpasswd?://192.168.56.11:464
+  ldap://192.168.56.10:3268
+  ldap://192.168.56.10:3269
+  ldap://192.168.56.10:389
+  ldap://192.168.56.10:636
+  ldap://192.168.56.11:3268
+  ldap://192.168.56.11:3269
+  ldap://192.168.56.11:389
+  ldap://192.168.56.11:636
+  llmnr://192.168.56.10:5355
+  llmnr://192.168.56.11:5355
+  llmnr://192.168.56.22:5355
+  msrdp://192.168.56.10:3389
+  msrdp://192.168.56.11:3389
+  msrdp://192.168.56.22:3389
+  mssql://192.168.56.22:1433
+  ncacn_http://192.168.56.10:49669
+  ncacn_http://192.168.56.11:49670
+  netbios-ns://192.168.56.10:137
+  netbios-ns://192.168.56.11:137
+  netbios-ns://192.168.56.22:137
+  ntp://192.168.56.10:123
+  ntp://192.168.56.11:123
+  smb://192.168.56.10:139
+  smb://192.168.56.11:139
+  smb://192.168.56.22:139
+  sybase://192.168.56.22:49813
+  unknown://192.168.56.10:9389
+  unknown://192.168.56.11:9389
+  www://192.168.56.10:47001
+  www://192.168.56.10:5985
+  www://192.168.56.10:5986
+  www://192.168.56.10:80
+  www://192.168.56.11:47001
+  www://192.168.56.11:5985
+  www://192.168.56.11:5986
+  www://192.168.56.22:47001
+  www://192.168.56.22:5985
+  www://192.168.56.22:5986
+  www://192.168.56.22:80
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w xml --multi-table]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="192.168.56.10">
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="53">
+          <services>
+            <service>dns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="80">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-IIS/10.0</banner>
+          </banners>
+        </port>
+        <port number="88">
+          <services>
+            <service>kerberos?</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="135">
+          <services>
+            <service>epmap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="139">
+          <services>
+            <service>smb</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="389">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="445">
+          <services>
+            <service>cifs</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="464">
+          <services>
+            <service>kpasswd?</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="593">
+          <services>
+            <service>http-rpc-epmap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="636">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3268">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3269">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3389">
+          <services>
+            <service>msrdp</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="5985">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="9389">
+          <banners/>
+        </port>
+        <port number="47001">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="49664">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49665">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49666">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49667">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49669">
+          <services>
+            <service>ncacn_http</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49670">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49672">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49675">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49685">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49785">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49863">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49966">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+      </tcp_ports>
+      <udp_ports>
+        <port number="53">
+          <services>
+            <service>dns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="123">
+          <services>
+            <service>ntp</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="137">
+          <services>
+            <service>netbios-ns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="5355">
+          <services>
+            <service>llmnr</service>
+          </services>
+          <banners/>
+        </port>
+      </udp_ports>
+    </host>
+    <host ip="192.168.56.11">
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="53">
+          <services>
+            <service>dns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="88">
+          <services>
+            <service>kerberos?</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="135">
+          <services>
+            <service>epmap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="139">
+          <services>
+            <service>smb</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="389">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="445">
+          <services>
+            <service>cifs</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="464">
+          <services>
+            <service>kpasswd?</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="593">
+          <services>
+            <service>http-rpc-epmap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="636">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3268">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3269">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3389">
+          <services>
+            <service>msrdp</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="5985">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="9389">
+          <banners/>
+        </port>
+        <port number="47001">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="49664">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49665">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49666">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49667">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49669">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49670">
+          <services>
+            <service>ncacn_http</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49673">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49676">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49722">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="65363">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="65464">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+      </tcp_ports>
+      <udp_ports>
+        <port number="53">
+          <services>
+            <service>dns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="123">
+          <services>
+            <service>ntp</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="137">
+          <services>
+            <service>netbios-ns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="5355">
+          <services>
+            <service>llmnr</service>
+          </services>
+          <banners/>
+        </port>
+      </udp_ports>
+    </host>
+    <host ip="192.168.56.22">
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="80">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-IIS/10.0</banner>
+          </banners>
+        </port>
+        <port number="135">
+          <services>
+            <service>epmap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="139">
+          <services>
+            <service>smb</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="445">
+          <services>
+            <service>cifs</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="1433">
+          <services>
+            <service>mssql</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3389">
+          <services>
+            <service>msrdp</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="5985">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="47001">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="49664">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49665">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49666">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49667">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49668">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49669">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49682">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49734">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49813">
+          <services>
+            <service>sybase</service>
+          </services>
+          <banners/>
+        </port>
+      </tcp_ports>
+      <udp_ports>
+        <port number="137">
+          <services>
+            <service>netbios-ns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="5355">
+          <services>
+            <service>llmnr</service>
+          </services>
+          <banners/>
+        </port>
+      </udp_ports>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w xml]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="192.168.56.10">
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="53">
+          <services>
+            <service>dns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="80">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-IIS/10.0</banner>
+          </banners>
+        </port>
+        <port number="88">
+          <services>
+            <service>kerberos?</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="135">
+          <services>
+            <service>epmap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="139">
+          <services>
+            <service>smb</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="389">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="445">
+          <services>
+            <service>cifs</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="464">
+          <services>
+            <service>kpasswd?</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="593">
+          <services>
+            <service>http-rpc-epmap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="636">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3268">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3269">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3389">
+          <services>
+            <service>msrdp</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="5985">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="9389">
+          <banners/>
+        </port>
+        <port number="47001">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="49664">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49665">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49666">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49667">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49669">
+          <services>
+            <service>ncacn_http</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49670">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49672">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49675">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49685">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49785">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49863">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49966">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+      </tcp_ports>
+      <udp_ports>
+        <port number="53">
+          <services>
+            <service>dns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="123">
+          <services>
+            <service>ntp</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="137">
+          <services>
+            <service>netbios-ns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="5355">
+          <services>
+            <service>llmnr</service>
+          </services>
+          <banners/>
+        </port>
+      </udp_ports>
+    </host>
+    <host ip="192.168.56.11">
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="53">
+          <services>
+            <service>dns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="88">
+          <services>
+            <service>kerberos?</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="135">
+          <services>
+            <service>epmap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="139">
+          <services>
+            <service>smb</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="389">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="445">
+          <services>
+            <service>cifs</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="464">
+          <services>
+            <service>kpasswd?</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="593">
+          <services>
+            <service>http-rpc-epmap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="636">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3268">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3269">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3389">
+          <services>
+            <service>msrdp</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="5985">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="9389">
+          <banners/>
+        </port>
+        <port number="47001">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="49664">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49665">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49666">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49667">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49669">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49670">
+          <services>
+            <service>ncacn_http</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49673">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49676">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49722">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="65363">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="65464">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+      </tcp_ports>
+      <udp_ports>
+        <port number="53">
+          <services>
+            <service>dns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="123">
+          <services>
+            <service>ntp</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="137">
+          <services>
+            <service>netbios-ns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="5355">
+          <services>
+            <service>llmnr</service>
+          </services>
+          <banners/>
+        </port>
+      </udp_ports>
+    </host>
+    <host ip="192.168.56.22">
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="80">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-IIS/10.0</banner>
+          </banners>
+        </port>
+        <port number="135">
+          <services>
+            <service>epmap</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="139">
+          <services>
+            <service>smb</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="445">
+          <services>
+            <service>cifs</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="1433">
+          <services>
+            <service>mssql</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="3389">
+          <services>
+            <service>msrdp</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="5985">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="47001">
+          <services>
+            <service>www</service>
+          </services>
+          <banners>
+            <banner>Microsoft-HTTPAPI/2.0</banner>
+          </banners>
+        </port>
+        <port number="49664">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49665">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49666">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49667">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49668">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49669">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49682">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49734">
+          <services>
+            <service>dce-rpc</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="49813">
+          <services>
+            <service>sybase</service>
+          </services>
+          <banners/>
+        </port>
+      </tcp_ports>
+      <udp_ports>
+        <port number="137">
+          <services>
+            <service>netbios-ns</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="5355">
+          <services>
+            <service>llmnr</service>
+          </services>
+          <banners/>
+        </port>
+      </udp_ports>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w yaml --multi-table]
+  '''
+  192.168.56.10:
+      hostnames: []
+      tcp_ports:
+          53:
+              service_names:
+              - dns
+              banners:
+              - ''
+          80:
+              service_names:
+              - www
+              banners:
+              - Microsoft-IIS/10.0
+          88:
+              service_names:
+              - kerberos?
+              banners:
+              - ''
+          135:
+              service_names:
+              - epmap
+              banners:
+              - ''
+          139:
+              service_names:
+              - smb
+              banners:
+              - ''
+          389:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          445:
+              service_names:
+              - cifs
+              banners:
+              - ''
+          464:
+              service_names:
+              - kpasswd?
+              banners:
+              - ''
+          593:
+              service_names:
+              - http-rpc-epmap
+              banners:
+              - ''
+          636:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          3268:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          3269:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          3389:
+              service_names:
+              - msrdp
+              banners:
+              - ''
+          5985:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          5986:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          9389:
+              service_names: []
+              banners:
+              - ''
+          47001:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          49664:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49665:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49666:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49667:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49669:
+              service_names:
+              - ncacn_http
+              banners:
+              - ''
+          49670:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49672:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49675:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49685:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49785:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49863:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49966:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+      udp_ports:
+          53:
+              service_names:
+              - dns
+              banners:
+              - ''
+          123:
+              service_names:
+              - ntp
+              banners:
+              - ''
+          137:
+              service_names:
+              - netbios-ns
+              banners:
+              - ''
+          5355:
+              service_names:
+              - llmnr
+              banners:
+              - ''
+      os:
+      - windows
+  192.168.56.11:
+      hostnames: []
+      tcp_ports:
+          53:
+              service_names:
+              - dns
+              banners:
+              - ''
+          88:
+              service_names:
+              - kerberos?
+              banners:
+              - ''
+          135:
+              service_names:
+              - epmap
+              banners:
+              - ''
+          139:
+              service_names:
+              - smb
+              banners:
+              - ''
+          389:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          445:
+              service_names:
+              - cifs
+              banners:
+              - ''
+          464:
+              service_names:
+              - kpasswd?
+              banners:
+              - ''
+          593:
+              service_names:
+              - http-rpc-epmap
+              banners:
+              - ''
+          636:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          3268:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          3269:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          3389:
+              service_names:
+              - msrdp
+              banners:
+              - ''
+          5985:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          5986:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          9389:
+              service_names: []
+              banners:
+              - ''
+          47001:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          49664:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49665:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49666:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49667:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49669:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49670:
+              service_names:
+              - ncacn_http
+              banners:
+              - ''
+          49673:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49676:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49722:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          65363:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          65464:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+      udp_ports:
+          53:
+              service_names:
+              - dns
+              banners:
+              - ''
+          123:
+              service_names:
+              - ntp
+              banners:
+              - ''
+          137:
+              service_names:
+              - netbios-ns
+              banners:
+              - ''
+          5355:
+              service_names:
+              - llmnr
+              banners:
+              - ''
+      os:
+      - windows
+  192.168.56.22:
+      hostnames: []
+      tcp_ports:
+          80:
+              service_names:
+              - www
+              banners:
+              - Microsoft-IIS/10.0
+          135:
+              service_names:
+              - epmap
+              banners:
+              - ''
+          139:
+              service_names:
+              - smb
+              banners:
+              - ''
+          445:
+              service_names:
+              - cifs
+              banners:
+              - ''
+          1433:
+              service_names:
+              - mssql
+              banners:
+              - ''
+          3389:
+              service_names:
+              - msrdp
+              banners:
+              - ''
+          5985:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          5986:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          47001:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          49664:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49665:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49666:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49667:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49668:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49669:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49682:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49734:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49813:
+              service_names:
+              - sybase
+              banners:
+              - ''
+      udp_ports:
+          137:
+              service_names:
+              - netbios-ns
+              banners:
+              - ''
+          5355:
+              service_names:
+              - llmnr
+              banners:
+              - ''
+      os:
+      - windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nessus tests/data/nessus/goad-light.nessus -w yaml]
+  '''
+  192.168.56.10:
+      hostnames: []
+      tcp_ports:
+          53:
+              service_names:
+              - dns
+              banners:
+              - ''
+          80:
+              service_names:
+              - www
+              banners:
+              - Microsoft-IIS/10.0
+          88:
+              service_names:
+              - kerberos?
+              banners:
+              - ''
+          135:
+              service_names:
+              - epmap
+              banners:
+              - ''
+          139:
+              service_names:
+              - smb
+              banners:
+              - ''
+          389:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          445:
+              service_names:
+              - cifs
+              banners:
+              - ''
+          464:
+              service_names:
+              - kpasswd?
+              banners:
+              - ''
+          593:
+              service_names:
+              - http-rpc-epmap
+              banners:
+              - ''
+          636:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          3268:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          3269:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          3389:
+              service_names:
+              - msrdp
+              banners:
+              - ''
+          5985:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          5986:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          9389:
+              service_names: []
+              banners:
+              - ''
+          47001:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          49664:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49665:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49666:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49667:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49669:
+              service_names:
+              - ncacn_http
+              banners:
+              - ''
+          49670:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49672:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49675:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49685:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49785:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49863:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49966:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+      udp_ports:
+          53:
+              service_names:
+              - dns
+              banners:
+              - ''
+          123:
+              service_names:
+              - ntp
+              banners:
+              - ''
+          137:
+              service_names:
+              - netbios-ns
+              banners:
+              - ''
+          5355:
+              service_names:
+              - llmnr
+              banners:
+              - ''
+      os:
+      - windows
+  192.168.56.11:
+      hostnames: []
+      tcp_ports:
+          53:
+              service_names:
+              - dns
+              banners:
+              - ''
+          88:
+              service_names:
+              - kerberos?
+              banners:
+              - ''
+          135:
+              service_names:
+              - epmap
+              banners:
+              - ''
+          139:
+              service_names:
+              - smb
+              banners:
+              - ''
+          389:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          445:
+              service_names:
+              - cifs
+              banners:
+              - ''
+          464:
+              service_names:
+              - kpasswd?
+              banners:
+              - ''
+          593:
+              service_names:
+              - http-rpc-epmap
+              banners:
+              - ''
+          636:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          3268:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          3269:
+              service_names:
+              - ldap
+              banners:
+              - ''
+          3389:
+              service_names:
+              - msrdp
+              banners:
+              - ''
+          5985:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          5986:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          9389:
+              service_names: []
+              banners:
+              - ''
+          47001:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          49664:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49665:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49666:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49667:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49669:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49670:
+              service_names:
+              - ncacn_http
+              banners:
+              - ''
+          49673:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49676:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49722:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          65363:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          65464:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+      udp_ports:
+          53:
+              service_names:
+              - dns
+              banners:
+              - ''
+          123:
+              service_names:
+              - ntp
+              banners:
+              - ''
+          137:
+              service_names:
+              - netbios-ns
+              banners:
+              - ''
+          5355:
+              service_names:
+              - llmnr
+              banners:
+              - ''
+      os:
+      - windows
+  192.168.56.22:
+      hostnames: []
+      tcp_ports:
+          80:
+              service_names:
+              - www
+              banners:
+              - Microsoft-IIS/10.0
+          135:
+              service_names:
+              - epmap
+              banners:
+              - ''
+          139:
+              service_names:
+              - smb
+              banners:
+              - ''
+          445:
+              service_names:
+              - cifs
+              banners:
+              - ''
+          1433:
+              service_names:
+              - mssql
+              banners:
+              - ''
+          3389:
+              service_names:
+              - msrdp
+              banners:
+              - ''
+          5985:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          5986:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          47001:
+              service_names:
+              - www
+              banners:
+              - Microsoft-HTTPAPI/2.0
+          49664:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49665:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49666:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49667:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49668:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49669:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49682:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49734:
+              service_names:
+              - dce-rpc
+              banners:
+              - ''
+          49813:
+              service_names:
+              - sybase
+              banners:
+              - ''
+      udp_ports:
+          137:
+              service_names:
+              - netbios-ns
+              banners:
+              - ''
+          5355:
+              service_names:
+              - llmnr
+              banners:
+              - ''
+      os:
+      - windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/ipv6/nmap/google.xml -w terminal]
+  '''
+  ╒══════════════════════════╤═══════════════════════════╤═════════╤════════════╤═══════════╤══════╕
+  │ IP-Addresses             │ Hostnames                 │ Ports   │ Services   │ Banners   │ OS   │
+  ╞══════════════════════════╪═══════════════════════════╪═════════╪════════════╪═══════════╪══════╡
+  │ 2a00:1450:4001:828::200e │ fra24s05-in-x0e.1e100.net │ 80/tcp  │ http       │           │      │
+  │                          │                           │ 443/tcp │ https      │           │      │
+  ╘══════════════════════════╧═══════════════════════════╧═════════╧════════════╧═══════════╧══════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w aquatone --multi-table]
+  '''
+  http://192.168.56.10:135
+  http://192.168.56.10:139
+  http://192.168.56.10:3268
+  http://192.168.56.10:3269
+  http://192.168.56.10:3389
+  http://192.168.56.10:389
+  http://192.168.56.10:445
+  http://192.168.56.10:464
+  http://192.168.56.10:53
+  http://192.168.56.10:593
+  http://192.168.56.10:5985
+  http://192.168.56.10:5986
+  http://192.168.56.10:636
+  http://192.168.56.10:80
+  http://192.168.56.10:88
+  http://192.168.56.11:135
+  http://192.168.56.11:139
+  http://192.168.56.11:3268
+  http://192.168.56.11:3269
+  http://192.168.56.11:3389
+  http://192.168.56.11:389
+  http://192.168.56.11:445
+  http://192.168.56.11:464
+  http://192.168.56.11:53
+  http://192.168.56.11:593
+  http://192.168.56.11:5985
+  http://192.168.56.11:5986
+  http://192.168.56.11:636
+  http://192.168.56.11:88
+  http://192.168.56.22:135
+  http://192.168.56.22:139
+  http://192.168.56.22:1433
+  http://192.168.56.22:3389
+  http://192.168.56.22:445
+  http://192.168.56.22:5985
+  http://192.168.56.22:5986
+  http://192.168.56.22:80
+  http://castelblack.north.sevenkingdoms.local:135
+  http://castelblack.north.sevenkingdoms.local:139
+  http://castelblack.north.sevenkingdoms.local:1433
+  http://castelblack.north.sevenkingdoms.local:3389
+  http://castelblack.north.sevenkingdoms.local:445
+  http://castelblack.north.sevenkingdoms.local:5985
+  http://castelblack.north.sevenkingdoms.local:5986
+  http://castelblack.north.sevenkingdoms.local:80
+  http://kingslanding.sevenkingdoms.local:135
+  http://kingslanding.sevenkingdoms.local:139
+  http://kingslanding.sevenkingdoms.local:3268
+  http://kingslanding.sevenkingdoms.local:3269
+  http://kingslanding.sevenkingdoms.local:3389
+  http://kingslanding.sevenkingdoms.local:389
+  http://kingslanding.sevenkingdoms.local:445
+  http://kingslanding.sevenkingdoms.local:464
+  http://kingslanding.sevenkingdoms.local:53
+  http://kingslanding.sevenkingdoms.local:593
+  http://kingslanding.sevenkingdoms.local:5985
+  http://kingslanding.sevenkingdoms.local:5986
+  http://kingslanding.sevenkingdoms.local:636
+  http://kingslanding.sevenkingdoms.local:80
+  http://kingslanding.sevenkingdoms.local:88
+  http://winterfell.north.sevenkingdoms.local:135
+  http://winterfell.north.sevenkingdoms.local:139
+  http://winterfell.north.sevenkingdoms.local:3268
+  http://winterfell.north.sevenkingdoms.local:3269
+  http://winterfell.north.sevenkingdoms.local:3389
+  http://winterfell.north.sevenkingdoms.local:389
+  http://winterfell.north.sevenkingdoms.local:445
+  http://winterfell.north.sevenkingdoms.local:464
+  http://winterfell.north.sevenkingdoms.local:53
+  http://winterfell.north.sevenkingdoms.local:593
+  http://winterfell.north.sevenkingdoms.local:5985
+  http://winterfell.north.sevenkingdoms.local:5986
+  http://winterfell.north.sevenkingdoms.local:636
+  http://winterfell.north.sevenkingdoms.local:88
+  https://192.168.56.10:135
+  https://192.168.56.10:139
+  https://192.168.56.10:3268
+  https://192.168.56.10:3269
+  https://192.168.56.10:3389
+  https://192.168.56.10:389
+  https://192.168.56.10:445
+  https://192.168.56.10:464
+  https://192.168.56.10:53
+  https://192.168.56.10:593
+  https://192.168.56.10:5985
+  https://192.168.56.10:5986
+  https://192.168.56.10:636
+  https://192.168.56.10:80
+  https://192.168.56.10:88
+  https://192.168.56.11:135
+  https://192.168.56.11:139
+  https://192.168.56.11:3268
+  https://192.168.56.11:3269
+  https://192.168.56.11:3389
+  https://192.168.56.11:389
+  https://192.168.56.11:445
+  https://192.168.56.11:464
+  https://192.168.56.11:53
+  https://192.168.56.11:593
+  https://192.168.56.11:5985
+  https://192.168.56.11:5986
+  https://192.168.56.11:636
+  https://192.168.56.11:88
+  https://192.168.56.22:135
+  https://192.168.56.22:139
+  https://192.168.56.22:1433
+  https://192.168.56.22:3389
+  https://192.168.56.22:445
+  https://192.168.56.22:5985
+  https://192.168.56.22:5986
+  https://192.168.56.22:80
+  https://castelblack.north.sevenkingdoms.local:135
+  https://castelblack.north.sevenkingdoms.local:139
+  https://castelblack.north.sevenkingdoms.local:1433
+  https://castelblack.north.sevenkingdoms.local:3389
+  https://castelblack.north.sevenkingdoms.local:445
+  https://castelblack.north.sevenkingdoms.local:5985
+  https://castelblack.north.sevenkingdoms.local:5986
+  https://castelblack.north.sevenkingdoms.local:80
+  https://kingslanding.sevenkingdoms.local:135
+  https://kingslanding.sevenkingdoms.local:139
+  https://kingslanding.sevenkingdoms.local:3268
+  https://kingslanding.sevenkingdoms.local:3269
+  https://kingslanding.sevenkingdoms.local:3389
+  https://kingslanding.sevenkingdoms.local:389
+  https://kingslanding.sevenkingdoms.local:445
+  https://kingslanding.sevenkingdoms.local:464
+  https://kingslanding.sevenkingdoms.local:53
+  https://kingslanding.sevenkingdoms.local:593
+  https://kingslanding.sevenkingdoms.local:5985
+  https://kingslanding.sevenkingdoms.local:5986
+  https://kingslanding.sevenkingdoms.local:636
+  https://kingslanding.sevenkingdoms.local:80
+  https://kingslanding.sevenkingdoms.local:88
+  https://winterfell.north.sevenkingdoms.local:135
+  https://winterfell.north.sevenkingdoms.local:139
+  https://winterfell.north.sevenkingdoms.local:3268
+  https://winterfell.north.sevenkingdoms.local:3269
+  https://winterfell.north.sevenkingdoms.local:3389
+  https://winterfell.north.sevenkingdoms.local:389
+  https://winterfell.north.sevenkingdoms.local:445
+  https://winterfell.north.sevenkingdoms.local:464
+  https://winterfell.north.sevenkingdoms.local:53
+  https://winterfell.north.sevenkingdoms.local:593
+  https://winterfell.north.sevenkingdoms.local:5985
+  https://winterfell.north.sevenkingdoms.local:5986
+  https://winterfell.north.sevenkingdoms.local:636
+  https://winterfell.north.sevenkingdoms.local:88
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w aquatone]
+  '''
+  http://192.168.56.10:135
+  http://192.168.56.10:139
+  http://192.168.56.10:3268
+  http://192.168.56.10:3269
+  http://192.168.56.10:3389
+  http://192.168.56.10:389
+  http://192.168.56.10:445
+  http://192.168.56.10:464
+  http://192.168.56.10:53
+  http://192.168.56.10:593
+  http://192.168.56.10:5985
+  http://192.168.56.10:5986
+  http://192.168.56.10:636
+  http://192.168.56.10:80
+  http://192.168.56.10:88
+  http://192.168.56.11:135
+  http://192.168.56.11:139
+  http://192.168.56.11:3268
+  http://192.168.56.11:3269
+  http://192.168.56.11:3389
+  http://192.168.56.11:389
+  http://192.168.56.11:445
+  http://192.168.56.11:464
+  http://192.168.56.11:53
+  http://192.168.56.11:593
+  http://192.168.56.11:5985
+  http://192.168.56.11:5986
+  http://192.168.56.11:636
+  http://192.168.56.11:88
+  http://192.168.56.22:135
+  http://192.168.56.22:139
+  http://192.168.56.22:1433
+  http://192.168.56.22:3389
+  http://192.168.56.22:445
+  http://192.168.56.22:5985
+  http://192.168.56.22:5986
+  http://192.168.56.22:80
+  http://castelblack.north.sevenkingdoms.local:135
+  http://castelblack.north.sevenkingdoms.local:139
+  http://castelblack.north.sevenkingdoms.local:1433
+  http://castelblack.north.sevenkingdoms.local:3389
+  http://castelblack.north.sevenkingdoms.local:445
+  http://castelblack.north.sevenkingdoms.local:5985
+  http://castelblack.north.sevenkingdoms.local:5986
+  http://castelblack.north.sevenkingdoms.local:80
+  http://kingslanding.sevenkingdoms.local:135
+  http://kingslanding.sevenkingdoms.local:139
+  http://kingslanding.sevenkingdoms.local:3268
+  http://kingslanding.sevenkingdoms.local:3269
+  http://kingslanding.sevenkingdoms.local:3389
+  http://kingslanding.sevenkingdoms.local:389
+  http://kingslanding.sevenkingdoms.local:445
+  http://kingslanding.sevenkingdoms.local:464
+  http://kingslanding.sevenkingdoms.local:53
+  http://kingslanding.sevenkingdoms.local:593
+  http://kingslanding.sevenkingdoms.local:5985
+  http://kingslanding.sevenkingdoms.local:5986
+  http://kingslanding.sevenkingdoms.local:636
+  http://kingslanding.sevenkingdoms.local:80
+  http://kingslanding.sevenkingdoms.local:88
+  http://winterfell.north.sevenkingdoms.local:135
+  http://winterfell.north.sevenkingdoms.local:139
+  http://winterfell.north.sevenkingdoms.local:3268
+  http://winterfell.north.sevenkingdoms.local:3269
+  http://winterfell.north.sevenkingdoms.local:3389
+  http://winterfell.north.sevenkingdoms.local:389
+  http://winterfell.north.sevenkingdoms.local:445
+  http://winterfell.north.sevenkingdoms.local:464
+  http://winterfell.north.sevenkingdoms.local:53
+  http://winterfell.north.sevenkingdoms.local:593
+  http://winterfell.north.sevenkingdoms.local:5985
+  http://winterfell.north.sevenkingdoms.local:5986
+  http://winterfell.north.sevenkingdoms.local:636
+  http://winterfell.north.sevenkingdoms.local:88
+  https://192.168.56.10:135
+  https://192.168.56.10:139
+  https://192.168.56.10:3268
+  https://192.168.56.10:3269
+  https://192.168.56.10:3389
+  https://192.168.56.10:389
+  https://192.168.56.10:445
+  https://192.168.56.10:464
+  https://192.168.56.10:53
+  https://192.168.56.10:593
+  https://192.168.56.10:5985
+  https://192.168.56.10:5986
+  https://192.168.56.10:636
+  https://192.168.56.10:80
+  https://192.168.56.10:88
+  https://192.168.56.11:135
+  https://192.168.56.11:139
+  https://192.168.56.11:3268
+  https://192.168.56.11:3269
+  https://192.168.56.11:3389
+  https://192.168.56.11:389
+  https://192.168.56.11:445
+  https://192.168.56.11:464
+  https://192.168.56.11:53
+  https://192.168.56.11:593
+  https://192.168.56.11:5985
+  https://192.168.56.11:5986
+  https://192.168.56.11:636
+  https://192.168.56.11:88
+  https://192.168.56.22:135
+  https://192.168.56.22:139
+  https://192.168.56.22:1433
+  https://192.168.56.22:3389
+  https://192.168.56.22:445
+  https://192.168.56.22:5985
+  https://192.168.56.22:5986
+  https://192.168.56.22:80
+  https://castelblack.north.sevenkingdoms.local:135
+  https://castelblack.north.sevenkingdoms.local:139
+  https://castelblack.north.sevenkingdoms.local:1433
+  https://castelblack.north.sevenkingdoms.local:3389
+  https://castelblack.north.sevenkingdoms.local:445
+  https://castelblack.north.sevenkingdoms.local:5985
+  https://castelblack.north.sevenkingdoms.local:5986
+  https://castelblack.north.sevenkingdoms.local:80
+  https://kingslanding.sevenkingdoms.local:135
+  https://kingslanding.sevenkingdoms.local:139
+  https://kingslanding.sevenkingdoms.local:3268
+  https://kingslanding.sevenkingdoms.local:3269
+  https://kingslanding.sevenkingdoms.local:3389
+  https://kingslanding.sevenkingdoms.local:389
+  https://kingslanding.sevenkingdoms.local:445
+  https://kingslanding.sevenkingdoms.local:464
+  https://kingslanding.sevenkingdoms.local:53
+  https://kingslanding.sevenkingdoms.local:593
+  https://kingslanding.sevenkingdoms.local:5985
+  https://kingslanding.sevenkingdoms.local:5986
+  https://kingslanding.sevenkingdoms.local:636
+  https://kingslanding.sevenkingdoms.local:80
+  https://kingslanding.sevenkingdoms.local:88
+  https://winterfell.north.sevenkingdoms.local:135
+  https://winterfell.north.sevenkingdoms.local:139
+  https://winterfell.north.sevenkingdoms.local:3268
+  https://winterfell.north.sevenkingdoms.local:3269
+  https://winterfell.north.sevenkingdoms.local:3389
+  https://winterfell.north.sevenkingdoms.local:389
+  https://winterfell.north.sevenkingdoms.local:445
+  https://winterfell.north.sevenkingdoms.local:464
+  https://winterfell.north.sevenkingdoms.local:53
+  https://winterfell.north.sevenkingdoms.local:593
+  https://winterfell.north.sevenkingdoms.local:5985
+  https://winterfell.north.sevenkingdoms.local:5986
+  https://winterfell.north.sevenkingdoms.local:636
+  https://winterfell.north.sevenkingdoms.local:88
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w csv --multi-table]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  192.168.56.10,kingslanding.sevenkingdoms.local,53/tcp,domain,Simple DNS Plus,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,80/tcp,http,Microsoft IIS httpd/10.0,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,88/tcp,kerberos\-sec,Microsoft Windows Kerberos,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,135/tcp,msrpc,Microsoft Windows RPC,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,139/tcp,netbios\-ssn,Microsoft Windows netbios\-ssn,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,389/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,445/tcp,microsoft\-ds,,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,464/tcp,kpasswd5,,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,593/tcp,ncacn_http,Microsoft Windows RPC over HTTP/1.0,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,636/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,3268/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,3269/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,3389/tcp,ms\-wbt\-server,Microsoft Terminal Services,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,5985/tcp,http,Microsoft HTTPAPI httpd/2.0,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,5986/tcp,http,Microsoft HTTPAPI httpd/2.0,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,53/tcp,domain,Simple DNS Plus,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,88/tcp,kerberos\-sec,Microsoft Windows Kerberos,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,135/tcp,msrpc,Microsoft Windows RPC,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,139/tcp,netbios\-ssn,Microsoft Windows netbios\-ssn,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,389/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,445/tcp,microsoft\-ds,,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,464/tcp,kpasswd5,,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,593/tcp,ncacn_http,Microsoft Windows RPC over HTTP/1.0,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,636/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,3268/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,3269/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,3389/tcp,ms\-wbt\-server,Microsoft Terminal Services,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,5985/tcp,http,Microsoft HTTPAPI httpd/2.0,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,5986/tcp,http,Microsoft HTTPAPI httpd/2.0,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,80/tcp,http,Microsoft IIS httpd/10.0,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,135/tcp,msrpc,Microsoft Windows RPC,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,139/tcp,netbios\-ssn,Microsoft Windows netbios\-ssn,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,445/tcp,microsoft\-ds,,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,1433/tcp,ms\-sql\-s,Microsoft SQL Server 2019/15.00.2000.00; RTM,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,3389/tcp,ms\-wbt\-server,Microsoft Terminal Services,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,5985/tcp,http,Microsoft HTTPAPI httpd/2.0,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,5986/tcp,http,Microsoft HTTPAPI httpd/2.0,windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w csv]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  192.168.56.10,kingslanding.sevenkingdoms.local,53/tcp,domain,Simple DNS Plus,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,80/tcp,http,Microsoft IIS httpd/10.0,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,88/tcp,kerberos\-sec,Microsoft Windows Kerberos,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,135/tcp,msrpc,Microsoft Windows RPC,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,139/tcp,netbios\-ssn,Microsoft Windows netbios\-ssn,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,389/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,445/tcp,microsoft\-ds,,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,464/tcp,kpasswd5,,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,593/tcp,ncacn_http,Microsoft Windows RPC over HTTP/1.0,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,636/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,3268/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,3269/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,3389/tcp,ms\-wbt\-server,Microsoft Terminal Services,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,5985/tcp,http,Microsoft HTTPAPI httpd/2.0,windows
+  192.168.56.10,kingslanding.sevenkingdoms.local,5986/tcp,http,Microsoft HTTPAPI httpd/2.0,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,53/tcp,domain,Simple DNS Plus,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,88/tcp,kerberos\-sec,Microsoft Windows Kerberos,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,135/tcp,msrpc,Microsoft Windows RPC,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,139/tcp,netbios\-ssn,Microsoft Windows netbios\-ssn,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,389/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,445/tcp,microsoft\-ds,,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,464/tcp,kpasswd5,,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,593/tcp,ncacn_http,Microsoft Windows RPC over HTTP/1.0,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,636/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,3268/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,3269/tcp,ldap,Microsoft Windows Active Directory LDAP,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,3389/tcp,ms\-wbt\-server,Microsoft Terminal Services,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,5985/tcp,http,Microsoft HTTPAPI httpd/2.0,windows
+  192.168.56.11,winterfell.north.sevenkingdoms.local,5986/tcp,http,Microsoft HTTPAPI httpd/2.0,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,80/tcp,http,Microsoft IIS httpd/10.0,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,135/tcp,msrpc,Microsoft Windows RPC,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,139/tcp,netbios\-ssn,Microsoft Windows netbios\-ssn,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,445/tcp,microsoft\-ds,,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,1433/tcp,ms\-sql\-s,Microsoft SQL Server 2019/15.00.2000.00; RTM,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,3389/tcp,ms\-wbt\-server,Microsoft Terminal Services,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,5985/tcp,http,Microsoft HTTPAPI httpd/2.0,windows
+  192.168.56.22,castelblack.north.sevenkingdoms.local,5986/tcp,http,Microsoft HTTPAPI httpd/2.0,windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w host --multi-table]
+  '''
+  192.168.56.10
+  192.168.56.11
+  192.168.56.22
+  castelblack.north.sevenkingdoms.local
+  kingslanding.sevenkingdoms.local
+  winterfell.north.sevenkingdoms.local
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w host]
+  '''
+  192.168.56.10
+  192.168.56.11
+  192.168.56.22
+  castelblack.north.sevenkingdoms.local
+  kingslanding.sevenkingdoms.local
+  winterfell.north.sevenkingdoms.local
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w html --multi-table]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.10</th>
+        <th>kingslanding.sevenkingdoms.local</th>
+        <th>windows</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>53/tcp</td>
+        <td>domain</td>
+        <td>Simple DNS Plus</td>
+      </tr>
+      <tr>
+        <td>80/tcp</td>
+        <td>http</td>
+        <td>Microsoft IIS httpd/10.0</td>
+      </tr>
+      <tr>
+        <td>88/tcp</td>
+        <td>kerberos-sec</td>
+        <td>Microsoft Windows Kerberos</td>
+      </tr>
+      <tr>
+        <td>135/tcp</td>
+        <td>msrpc</td>
+        <td>Microsoft Windows RPC</td>
+      </tr>
+      <tr>
+        <td>139/tcp</td>
+        <td>netbios-ssn</td>
+        <td>Microsoft Windows netbios-ssn</td>
+      </tr>
+      <tr>
+        <td>389/tcp</td>
+        <td>ldap</td>
+        <td>Microsoft Windows Active Directory LDAP</td>
+      </tr>
+      <tr>
+        <td>445/tcp</td>
+        <td>microsoft-ds</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>464/tcp</td>
+        <td>kpasswd5</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>593/tcp</td>
+        <td>ncacn_http</td>
+        <td>Microsoft Windows RPC over HTTP/1.0</td>
+      </tr>
+      <tr>
+        <td>636/tcp</td>
+        <td>ldap</td>
+        <td>Microsoft Windows Active Directory LDAP</td>
+      </tr>
+      <tr>
+        <td>3268/tcp</td>
+        <td>ldap</td>
+        <td>Microsoft Windows Active Directory LDAP</td>
+      </tr>
+      <tr>
+        <td>3269/tcp</td>
+        <td>ldap</td>
+        <td>Microsoft Windows Active Directory LDAP</td>
+      </tr>
+      <tr>
+        <td>3389/tcp</td>
+        <td>ms-wbt-server</td>
+        <td>Microsoft Terminal Services</td>
+      </tr>
+      <tr>
+        <td>5985/tcp</td>
+        <td>http</td>
+        <td>Microsoft HTTPAPI httpd/2.0</td>
+      </tr>
+      <tr>
+        <td>5986/tcp</td>
+        <td>http</td>
+        <td>Microsoft HTTPAPI httpd/2.0</td>
+      </tr>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.11</th>
+        <th>winterfell.north.sevenkingdoms.local</th>
+        <th>windows</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>53/tcp</td>
+        <td>domain</td>
+        <td>Simple DNS Plus</td>
+      </tr>
+      <tr>
+        <td>88/tcp</td>
+        <td>kerberos-sec</td>
+        <td>Microsoft Windows Kerberos</td>
+      </tr>
+      <tr>
+        <td>135/tcp</td>
+        <td>msrpc</td>
+        <td>Microsoft Windows RPC</td>
+      </tr>
+      <tr>
+        <td>139/tcp</td>
+        <td>netbios-ssn</td>
+        <td>Microsoft Windows netbios-ssn</td>
+      </tr>
+      <tr>
+        <td>389/tcp</td>
+        <td>ldap</td>
+        <td>Microsoft Windows Active Directory LDAP</td>
+      </tr>
+      <tr>
+        <td>445/tcp</td>
+        <td>microsoft-ds</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>464/tcp</td>
+        <td>kpasswd5</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>593/tcp</td>
+        <td>ncacn_http</td>
+        <td>Microsoft Windows RPC over HTTP/1.0</td>
+      </tr>
+      <tr>
+        <td>636/tcp</td>
+        <td>ldap</td>
+        <td>Microsoft Windows Active Directory LDAP</td>
+      </tr>
+      <tr>
+        <td>3268/tcp</td>
+        <td>ldap</td>
+        <td>Microsoft Windows Active Directory LDAP</td>
+      </tr>
+      <tr>
+        <td>3269/tcp</td>
+        <td>ldap</td>
+        <td>Microsoft Windows Active Directory LDAP</td>
+      </tr>
+      <tr>
+        <td>3389/tcp</td>
+        <td>ms-wbt-server</td>
+        <td>Microsoft Terminal Services</td>
+      </tr>
+      <tr>
+        <td>5985/tcp</td>
+        <td>http</td>
+        <td>Microsoft HTTPAPI httpd/2.0</td>
+      </tr>
+      <tr>
+        <td>5986/tcp</td>
+        <td>http</td>
+        <td>Microsoft HTTPAPI httpd/2.0</td>
+      </tr>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.22</th>
+        <th>castelblack.north.sevenkingdoms.local</th>
+        <th>windows</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>80/tcp</td>
+        <td>http</td>
+        <td>Microsoft IIS httpd/10.0</td>
+      </tr>
+      <tr>
+        <td>135/tcp</td>
+        <td>msrpc</td>
+        <td>Microsoft Windows RPC</td>
+      </tr>
+      <tr>
+        <td>139/tcp</td>
+        <td>netbios-ssn</td>
+        <td>Microsoft Windows netbios-ssn</td>
+      </tr>
+      <tr>
+        <td>445/tcp</td>
+        <td>microsoft-ds</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>1433/tcp</td>
+        <td>ms-sql-s</td>
+        <td>Microsoft SQL Server 2019/15.00.2000.00; RTM</td>
+      </tr>
+      <tr>
+        <td>3389/tcp</td>
+        <td>ms-wbt-server</td>
+        <td>Microsoft Terminal Services</td>
+      </tr>
+      <tr>
+        <td>5985/tcp</td>
+        <td>http</td>
+        <td>Microsoft HTTPAPI httpd/2.0</td>
+      </tr>
+      <tr>
+        <td>5986/tcp</td>
+        <td>http</td>
+        <td>Microsoft HTTPAPI httpd/2.0</td>
+      </tr>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w html]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>IP-Addresses</th>
+        <th>Hostnames</th>
+        <th>Ports</th>
+        <th>Services</th>
+        <th>Banners</th>
+        <th>OS</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>192.168.56.10</td>
+        <td>kingslanding.sevenkingdoms.local</td>
+        <td>53/tcp<br>80/tcp<br>88/tcp<br>135/tcp<br>139/tcp<br>389/tcp<br>445/tcp<br>464/tcp<br>593/tcp<br>636/tcp<br>3268/tcp<br>3269/tcp<br>3389/tcp<br>5985/tcp<br>5986/tcp</td>
+        <td>domain<br>http<br>kerberos-sec<br>msrpc<br>netbios-ssn<br>ldap<br>microsoft-ds<br>kpasswd5<br>ncacn_http<br>ldap<br>ldap<br>ldap<br>ms-wbt-server<br>http<br>http</td>
+        <td>Simple DNS Plus<br>Microsoft IIS httpd/10.0<br>Microsoft Windows Kerberos<br>Microsoft Windows RPC<br>Microsoft Windows netbios-ssn<br>Microsoft Windows Active Directory LDAP<br><br><br>Microsoft Windows RPC over HTTP/1.0<br>Microsoft Windows Active Directory LDAP<br>Microsoft Windows Active Directory LDAP<br>Microsoft Windows Active Directory LDAP<br>Microsoft Terminal Services<br>Microsoft HTTPAPI httpd/2.0<br>Microsoft HTTPAPI httpd/2.0</td>
+        <td>windows</td>
+      </tr>
+      <tr>
+        <td>192.168.56.11</td>
+        <td>winterfell.north.sevenkingdoms.local</td>
+        <td>53/tcp<br>88/tcp<br>135/tcp<br>139/tcp<br>389/tcp<br>445/tcp<br>464/tcp<br>593/tcp<br>636/tcp<br>3268/tcp<br>3269/tcp<br>3389/tcp<br>5985/tcp<br>5986/tcp</td>
+        <td>domain<br>kerberos-sec<br>msrpc<br>netbios-ssn<br>ldap<br>microsoft-ds<br>kpasswd5<br>ncacn_http<br>ldap<br>ldap<br>ldap<br>ms-wbt-server<br>http<br>http</td>
+        <td>Simple DNS Plus<br>Microsoft Windows Kerberos<br>Microsoft Windows RPC<br>Microsoft Windows netbios-ssn<br>Microsoft Windows Active Directory LDAP<br><br><br>Microsoft Windows RPC over HTTP/1.0<br>Microsoft Windows Active Directory LDAP<br>Microsoft Windows Active Directory LDAP<br>Microsoft Windows Active Directory LDAP<br>Microsoft Terminal Services<br>Microsoft HTTPAPI httpd/2.0<br>Microsoft HTTPAPI httpd/2.0</td>
+        <td>windows</td>
+      </tr>
+      <tr>
+        <td>192.168.56.22</td>
+        <td>castelblack.north.sevenkingdoms.local</td>
+        <td>80/tcp<br>135/tcp<br>139/tcp<br>445/tcp<br>1433/tcp<br>3389/tcp<br>5985/tcp<br>5986/tcp</td>
+        <td>http<br>msrpc<br>netbios-ssn<br>microsoft-ds<br>ms-sql-s<br>ms-wbt-server<br>http<br>http</td>
+        <td>Microsoft IIS httpd/10.0<br>Microsoft Windows RPC<br>Microsoft Windows netbios-ssn<br><br>Microsoft SQL Server 2019/15.00.2000.00; RTM<br>Microsoft Terminal Services<br>Microsoft HTTPAPI httpd/2.0<br>Microsoft HTTPAPI httpd/2.0</td>
+        <td>windows</td>
+      </tr>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w json --multi-table]
+  '''
+  {"192.168.56.10":{"hostnames":["kingslanding.sevenkingdoms.local"],"tcp_ports":{"53":{"service_names":["domain"],"banners":["Simple DNS Plus"]},"80":{"service_names":["http"],"banners":["Microsoft IIS httpd\/10.0"]},"88":{"service_names":["kerberos-sec"],"banners":["Microsoft Windows Kerberos"]},"135":{"service_names":["msrpc"],"banners":["Microsoft Windows RPC"]},"139":{"service_names":["netbios-ssn"],"banners":["Microsoft Windows netbios-ssn"]},"389":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"445":{"service_names":["microsoft-ds"],"banners":[""]},"464":{"service_names":["kpasswd5"],"banners":[""]},"593":{"service_names":["ncacn_http"],"banners":["Microsoft Windows RPC over HTTP\/1.0"]},"636":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"3268":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"3269":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"3389":{"service_names":["ms-wbt-server"],"banners":["Microsoft Terminal Services"]},"5985":{"service_names":["http"],"banners":["Microsoft HTTPAPI httpd\/2.0"]},"5986":{"service_names":["http"],"banners":["Microsoft HTTPAPI httpd\/2.0"]}},"udp_ports":{},"os":["windows"]},"192.168.56.11":{"hostnames":["winterfell.north.sevenkingdoms.local"],"tcp_ports":{"53":{"service_names":["domain"],"banners":["Simple DNS Plus"]},"88":{"service_names":["kerberos-sec"],"banners":["Microsoft Windows Kerberos"]},"135":{"service_names":["msrpc"],"banners":["Microsoft Windows RPC"]},"139":{"service_names":["netbios-ssn"],"banners":["Microsoft Windows netbios-ssn"]},"389":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"445":{"service_names":["microsoft-ds"],"banners":[""]},"464":{"service_names":["kpasswd5"],"banners":[""]},"593":{"service_names":["ncacn_http"],"banners":["Microsoft Windows RPC over HTTP\/1.0"]},"636":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"3268":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"3269":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"3389":{"service_names":["ms-wbt-server"],"banners":["Microsoft Terminal Services"]},"5985":{"service_names":["http"],"banners":["Microsoft HTTPAPI httpd\/2.0"]},"5986":{"service_names":["http"],"banners":["Microsoft HTTPAPI httpd\/2.0"]}},"udp_ports":{},"os":["windows"]},"192.168.56.22":{"hostnames":["castelblack.north.sevenkingdoms.local"],"tcp_ports":{"80":{"service_names":["http"],"banners":["Microsoft IIS httpd\/10.0"]},"135":{"service_names":["msrpc"],"banners":["Microsoft Windows RPC"]},"139":{"service_names":["netbios-ssn"],"banners":["Microsoft Windows netbios-ssn"]},"445":{"service_names":["microsoft-ds"],"banners":[""]},"1433":{"service_names":["ms-sql-s"],"banners":["Microsoft SQL Server 2019\/15.00.2000.00; RTM"]},"3389":{"service_names":["ms-wbt-server"],"banners":["Microsoft Terminal Services"]},"5985":{"service_names":["http"],"banners":["Microsoft HTTPAPI httpd\/2.0"]},"5986":{"service_names":["http"],"banners":["Microsoft HTTPAPI httpd\/2.0"]}},"udp_ports":{},"os":["windows"]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w json]
+  '''
+  {"192.168.56.10":{"hostnames":["kingslanding.sevenkingdoms.local"],"tcp_ports":{"53":{"service_names":["domain"],"banners":["Simple DNS Plus"]},"80":{"service_names":["http"],"banners":["Microsoft IIS httpd\/10.0"]},"88":{"service_names":["kerberos-sec"],"banners":["Microsoft Windows Kerberos"]},"135":{"service_names":["msrpc"],"banners":["Microsoft Windows RPC"]},"139":{"service_names":["netbios-ssn"],"banners":["Microsoft Windows netbios-ssn"]},"389":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"445":{"service_names":["microsoft-ds"],"banners":[""]},"464":{"service_names":["kpasswd5"],"banners":[""]},"593":{"service_names":["ncacn_http"],"banners":["Microsoft Windows RPC over HTTP\/1.0"]},"636":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"3268":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"3269":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"3389":{"service_names":["ms-wbt-server"],"banners":["Microsoft Terminal Services"]},"5985":{"service_names":["http"],"banners":["Microsoft HTTPAPI httpd\/2.0"]},"5986":{"service_names":["http"],"banners":["Microsoft HTTPAPI httpd\/2.0"]}},"udp_ports":{},"os":["windows"]},"192.168.56.11":{"hostnames":["winterfell.north.sevenkingdoms.local"],"tcp_ports":{"53":{"service_names":["domain"],"banners":["Simple DNS Plus"]},"88":{"service_names":["kerberos-sec"],"banners":["Microsoft Windows Kerberos"]},"135":{"service_names":["msrpc"],"banners":["Microsoft Windows RPC"]},"139":{"service_names":["netbios-ssn"],"banners":["Microsoft Windows netbios-ssn"]},"389":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"445":{"service_names":["microsoft-ds"],"banners":[""]},"464":{"service_names":["kpasswd5"],"banners":[""]},"593":{"service_names":["ncacn_http"],"banners":["Microsoft Windows RPC over HTTP\/1.0"]},"636":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"3268":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"3269":{"service_names":["ldap"],"banners":["Microsoft Windows Active Directory LDAP"]},"3389":{"service_names":["ms-wbt-server"],"banners":["Microsoft Terminal Services"]},"5985":{"service_names":["http"],"banners":["Microsoft HTTPAPI httpd\/2.0"]},"5986":{"service_names":["http"],"banners":["Microsoft HTTPAPI httpd\/2.0"]}},"udp_ports":{},"os":["windows"]},"192.168.56.22":{"hostnames":["castelblack.north.sevenkingdoms.local"],"tcp_ports":{"80":{"service_names":["http"],"banners":["Microsoft IIS httpd\/10.0"]},"135":{"service_names":["msrpc"],"banners":["Microsoft Windows RPC"]},"139":{"service_names":["netbios-ssn"],"banners":["Microsoft Windows netbios-ssn"]},"445":{"service_names":["microsoft-ds"],"banners":[""]},"1433":{"service_names":["ms-sql-s"],"banners":["Microsoft SQL Server 2019\/15.00.2000.00; RTM"]},"3389":{"service_names":["ms-wbt-server"],"banners":["Microsoft Terminal Services"]},"5985":{"service_names":["http"],"banners":["Microsoft HTTPAPI httpd\/2.0"]},"5986":{"service_names":["http"],"banners":["Microsoft HTTPAPI httpd\/2.0"]}},"udp_ports":{},"os":["windows"]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w latex --multi-table]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.10} & \makecell[l]{kingslanding.sevenkingdoms.local} & \makecell[l]{windows} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.10} & \makecell[l]{kingslanding.sevenkingdoms.local} & \makecell[l]{windows} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{53/tcp} & \makecell[l]{domain} & \makecell[l]{Simple DNS Plus} \\
+  \makecell[l]{80/tcp} & \makecell[l]{http} & \makecell[l]{Microsoft IIS httpd/10.0} \\
+  \makecell[l]{88/tcp} & \makecell[l]{kerberos-sec} & \makecell[l]{Microsoft Windows Kerberos} \\
+  \makecell[l]{135/tcp} & \makecell[l]{msrpc} & \makecell[l]{Microsoft Windows RPC} \\
+  \makecell[l]{139/tcp} & \makecell[l]{netbios-ssn} & \makecell[l]{Microsoft Windows netbios-ssn} \\
+  \makecell[l]{389/tcp} & \makecell[l]{ldap} & \makecell[l]{Microsoft Windows Active Directory LDAP} \\
+  \makecell[l]{445/tcp} & \makecell[l]{microsoft-ds} & \makecell[l]{} \\
+  \makecell[l]{464/tcp} & \makecell[l]{kpasswd5} & \makecell[l]{} \\
+  \makecell[l]{593/tcp} & \makecell[l]{ncacn\_http} & \makecell[l]{Microsoft Windows RPC over HTTP/1.0} \\
+  \makecell[l]{636/tcp} & \makecell[l]{ldap} & \makecell[l]{Microsoft Windows Active Directory LDAP} \\
+  \makecell[l]{3268/tcp} & \makecell[l]{ldap} & \makecell[l]{Microsoft Windows Active Directory LDAP} \\
+  \makecell[l]{3269/tcp} & \makecell[l]{ldap} & \makecell[l]{Microsoft Windows Active Directory LDAP} \\
+  \makecell[l]{3389/tcp} & \makecell[l]{ms-wbt-server} & \makecell[l]{Microsoft Terminal Services} \\
+  \makecell[l]{5985/tcp} & \makecell[l]{http} & \makecell[l]{Microsoft HTTPAPI httpd/2.0} \\
+  \makecell[l]{5986/tcp} & \makecell[l]{http} & \makecell[l]{Microsoft HTTPAPI httpd/2.0} \\
+  \end{longtable}
+  
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.11} & \makecell[l]{winterfell.north.sevenkingdoms.local} & \makecell[l]{windows} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.11} & \makecell[l]{winterfell.north.sevenkingdoms.local} & \makecell[l]{windows} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{53/tcp} & \makecell[l]{domain} & \makecell[l]{Simple DNS Plus} \\
+  \makecell[l]{88/tcp} & \makecell[l]{kerberos-sec} & \makecell[l]{Microsoft Windows Kerberos} \\
+  \makecell[l]{135/tcp} & \makecell[l]{msrpc} & \makecell[l]{Microsoft Windows RPC} \\
+  \makecell[l]{139/tcp} & \makecell[l]{netbios-ssn} & \makecell[l]{Microsoft Windows netbios-ssn} \\
+  \makecell[l]{389/tcp} & \makecell[l]{ldap} & \makecell[l]{Microsoft Windows Active Directory LDAP} \\
+  \makecell[l]{445/tcp} & \makecell[l]{microsoft-ds} & \makecell[l]{} \\
+  \makecell[l]{464/tcp} & \makecell[l]{kpasswd5} & \makecell[l]{} \\
+  \makecell[l]{593/tcp} & \makecell[l]{ncacn\_http} & \makecell[l]{Microsoft Windows RPC over HTTP/1.0} \\
+  \makecell[l]{636/tcp} & \makecell[l]{ldap} & \makecell[l]{Microsoft Windows Active Directory LDAP} \\
+  \makecell[l]{3268/tcp} & \makecell[l]{ldap} & \makecell[l]{Microsoft Windows Active Directory LDAP} \\
+  \makecell[l]{3269/tcp} & \makecell[l]{ldap} & \makecell[l]{Microsoft Windows Active Directory LDAP} \\
+  \makecell[l]{3389/tcp} & \makecell[l]{ms-wbt-server} & \makecell[l]{Microsoft Terminal Services} \\
+  \makecell[l]{5985/tcp} & \makecell[l]{http} & \makecell[l]{Microsoft HTTPAPI httpd/2.0} \\
+  \makecell[l]{5986/tcp} & \makecell[l]{http} & \makecell[l]{Microsoft HTTPAPI httpd/2.0} \\
+  \end{longtable}
+  
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.22} & \makecell[l]{castelblack.north.sevenkingdoms.local} & \makecell[l]{windows} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.22} & \makecell[l]{castelblack.north.sevenkingdoms.local} & \makecell[l]{windows} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{80/tcp} & \makecell[l]{http} & \makecell[l]{Microsoft IIS httpd/10.0} \\
+  \makecell[l]{135/tcp} & \makecell[l]{msrpc} & \makecell[l]{Microsoft Windows RPC} \\
+  \makecell[l]{139/tcp} & \makecell[l]{netbios-ssn} & \makecell[l]{Microsoft Windows netbios-ssn} \\
+  \makecell[l]{445/tcp} & \makecell[l]{microsoft-ds} & \makecell[l]{} \\
+  \makecell[l]{1433/tcp} & \makecell[l]{ms-sql-s} & \makecell[l]{Microsoft SQL Server 2019/15.00.2000.00; RTM} \\
+  \makecell[l]{3389/tcp} & \makecell[l]{ms-wbt-server} & \makecell[l]{Microsoft Terminal Services} \\
+  \makecell[l]{5985/tcp} & \makecell[l]{http} & \makecell[l]{Microsoft HTTPAPI httpd/2.0} \\
+  \makecell[l]{5986/tcp} & \makecell[l]{http} & \makecell[l]{Microsoft HTTPAPI httpd/2.0} \\
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w latex]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{llllll}
+  \caption{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{6}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{192.168.56.10} & \makecell[l]{kingslanding.sevenkingdoms.local} & \makecell[l]{53/tcp \\ 80/tcp \\ 88/tcp \\ 135/tcp \\ 139/tcp \\ 389/tcp \\ 445/tcp \\ 464/tcp \\ 593/tcp \\ 636/tcp \\ 3268/tcp \\ 3269/tcp \\ 3389/tcp \\ 5985/tcp \\ 5986/tcp} & \makecell[l]{domain \\ http \\ kerberos-sec \\ msrpc \\ netbios-ssn \\ ldap \\ microsoft-ds \\ kpasswd5 \\ ncacn\_http \\ ldap \\ ldap \\ ldap \\ ms-wbt-server \\ http \\ http} & \makecell[l]{Simple DNS Plus \\ Microsoft IIS httpd/10.0 \\ Microsoft Windows Kerberos \\ Microsoft Windows RPC \\ Microsoft Windows netbios-ssn \\ Microsoft Windows Active Directory LDAP \\  \\  \\ Microsoft Windows RPC over HTTP/1.0 \\ Microsoft Windows Active Directory LDAP \\ Microsoft Windows Active Directory LDAP \\ Microsoft Windows Active Directory LDAP \\ Microsoft Terminal Services \\ Microsoft HTTPAPI httpd/2.0 \\ Microsoft HTTPAPI httpd/2.0} & \makecell[l]{windows} \\
+  \makecell[l]{192.168.56.11} & \makecell[l]{winterfell.north.sevenkingdoms.local} & \makecell[l]{53/tcp \\ 88/tcp \\ 135/tcp \\ 139/tcp \\ 389/tcp \\ 445/tcp \\ 464/tcp \\ 593/tcp \\ 636/tcp \\ 3268/tcp \\ 3269/tcp \\ 3389/tcp \\ 5985/tcp \\ 5986/tcp} & \makecell[l]{domain \\ kerberos-sec \\ msrpc \\ netbios-ssn \\ ldap \\ microsoft-ds \\ kpasswd5 \\ ncacn\_http \\ ldap \\ ldap \\ ldap \\ ms-wbt-server \\ http \\ http} & \makecell[l]{Simple DNS Plus \\ Microsoft Windows Kerberos \\ Microsoft Windows RPC \\ Microsoft Windows netbios-ssn \\ Microsoft Windows Active Directory LDAP \\  \\  \\ Microsoft Windows RPC over HTTP/1.0 \\ Microsoft Windows Active Directory LDAP \\ Microsoft Windows Active Directory LDAP \\ Microsoft Windows Active Directory LDAP \\ Microsoft Terminal Services \\ Microsoft HTTPAPI httpd/2.0 \\ Microsoft HTTPAPI httpd/2.0} & \makecell[l]{windows} \\
+  \makecell[l]{192.168.56.22} & \makecell[l]{castelblack.north.sevenkingdoms.local} & \makecell[l]{80/tcp \\ 135/tcp \\ 139/tcp \\ 445/tcp \\ 1433/tcp \\ 3389/tcp \\ 5985/tcp \\ 5986/tcp} & \makecell[l]{http \\ msrpc \\ netbios-ssn \\ microsoft-ds \\ ms-sql-s \\ ms-wbt-server \\ http \\ http} & \makecell[l]{Microsoft IIS httpd/10.0 \\ Microsoft Windows RPC \\ Microsoft Windows netbios-ssn \\  \\ Microsoft SQL Server 2019/15.00.2000.00; RTM \\ Microsoft Terminal Services \\ Microsoft HTTPAPI httpd/2.0 \\ Microsoft HTTPAPI httpd/2.0} & \makecell[l]{windows} \\
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w markdown --multi-table]
+  '''
+  | 192.168.56.10   | kingslanding.sevenkingdoms.local   | windows                                 |
+  |:----------------|:-----------------------------------|:----------------------------------------|
+  | 53/tcp          | domain                             | Simple DNS Plus                         |
+  | 80/tcp          | http                               | Microsoft IIS httpd/10.0                |
+  | 88/tcp          | kerberos-sec                       | Microsoft Windows Kerberos              |
+  | 135/tcp         | msrpc                              | Microsoft Windows RPC                   |
+  | 139/tcp         | netbios-ssn                        | Microsoft Windows netbios-ssn           |
+  | 389/tcp         | ldap                               | Microsoft Windows Active Directory LDAP |
+  | 445/tcp         | microsoft-ds                       |                                         |
+  | 464/tcp         | kpasswd5                           |                                         |
+  | 593/tcp         | ncacn\_http                        | Microsoft Windows RPC over HTTP/1.0     |
+  | 636/tcp         | ldap                               | Microsoft Windows Active Directory LDAP |
+  | 3268/tcp        | ldap                               | Microsoft Windows Active Directory LDAP |
+  | 3269/tcp        | ldap                               | Microsoft Windows Active Directory LDAP |
+  | 3389/tcp        | ms-wbt-server                      | Microsoft Terminal Services             |
+  | 5985/tcp        | http                               | Microsoft HTTPAPI httpd/2.0             |
+  | 5986/tcp        | http                               | Microsoft HTTPAPI httpd/2.0             |
+  
+  
+  | 192.168.56.11   | winterfell.north.sevenkingdoms.local   | windows                                 |
+  |:----------------|:---------------------------------------|:----------------------------------------|
+  | 53/tcp          | domain                                 | Simple DNS Plus                         |
+  | 88/tcp          | kerberos-sec                           | Microsoft Windows Kerberos              |
+  | 135/tcp         | msrpc                                  | Microsoft Windows RPC                   |
+  | 139/tcp         | netbios-ssn                            | Microsoft Windows netbios-ssn           |
+  | 389/tcp         | ldap                                   | Microsoft Windows Active Directory LDAP |
+  | 445/tcp         | microsoft-ds                           |                                         |
+  | 464/tcp         | kpasswd5                               |                                         |
+  | 593/tcp         | ncacn\_http                            | Microsoft Windows RPC over HTTP/1.0     |
+  | 636/tcp         | ldap                                   | Microsoft Windows Active Directory LDAP |
+  | 3268/tcp        | ldap                                   | Microsoft Windows Active Directory LDAP |
+  | 3269/tcp        | ldap                                   | Microsoft Windows Active Directory LDAP |
+  | 3389/tcp        | ms-wbt-server                          | Microsoft Terminal Services             |
+  | 5985/tcp        | http                                   | Microsoft HTTPAPI httpd/2.0             |
+  | 5986/tcp        | http                                   | Microsoft HTTPAPI httpd/2.0             |
+  
+  
+  | 192.168.56.22   | castelblack.north.sevenkingdoms.local   | windows                                      |
+  |:----------------|:----------------------------------------|:---------------------------------------------|
+  | 80/tcp          | http                                    | Microsoft IIS httpd/10.0                     |
+  | 135/tcp         | msrpc                                   | Microsoft Windows RPC                        |
+  | 139/tcp         | netbios-ssn                             | Microsoft Windows netbios-ssn                |
+  | 445/tcp         | microsoft-ds                            |                                              |
+  | 1433/tcp        | ms-sql-s                                | Microsoft SQL Server 2019/15.00.2000.00; RTM |
+  | 3389/tcp        | ms-wbt-server                           | Microsoft Terminal Services                  |
+  | 5985/tcp        | http                                    | Microsoft HTTPAPI httpd/2.0                  |
+  | 5986/tcp        | http                                    | Microsoft HTTPAPI httpd/2.0                  |
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w markdown]
+  '''
+  | IP-Addresses   | Hostnames                             | Ports                                                                                                                                                               | Services                                                                                                                                                           | Banners                                                                                                                                                                                                                                                                                                                                                                                                                                                     | OS      |
+  |:---------------|:--------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------|
+  | 192.168.56.10  | kingslanding.sevenkingdoms.local      | 53/tcp<br>80/tcp<br>88/tcp<br>135/tcp<br>139/tcp<br>389/tcp<br>445/tcp<br>464/tcp<br>593/tcp<br>636/tcp<br>3268/tcp<br>3269/tcp<br>3389/tcp<br>5985/tcp<br>5986/tcp | domain<br>http<br>kerberos-sec<br>msrpc<br>netbios-ssn<br>ldap<br>microsoft-ds<br>kpasswd5<br>ncacn\_http<br>ldap<br>ldap<br>ldap<br>ms-wbt-server<br>http<br>http | Simple DNS Plus<br>Microsoft IIS httpd/10.0<br>Microsoft Windows Kerberos<br>Microsoft Windows RPC<br>Microsoft Windows netbios-ssn<br>Microsoft Windows Active Directory LDAP<br><br><br>Microsoft Windows RPC over HTTP/1.0<br>Microsoft Windows Active Directory LDAP<br>Microsoft Windows Active Directory LDAP<br>Microsoft Windows Active Directory LDAP<br>Microsoft Terminal Services<br>Microsoft HTTPAPI httpd/2.0<br>Microsoft HTTPAPI httpd/2.0 | windows |
+  | 192.168.56.11  | winterfell.north.sevenkingdoms.local  | 53/tcp<br>88/tcp<br>135/tcp<br>139/tcp<br>389/tcp<br>445/tcp<br>464/tcp<br>593/tcp<br>636/tcp<br>3268/tcp<br>3269/tcp<br>3389/tcp<br>5985/tcp<br>5986/tcp           | domain<br>kerberos-sec<br>msrpc<br>netbios-ssn<br>ldap<br>microsoft-ds<br>kpasswd5<br>ncacn\_http<br>ldap<br>ldap<br>ldap<br>ms-wbt-server<br>http<br>http         | Simple DNS Plus<br>Microsoft Windows Kerberos<br>Microsoft Windows RPC<br>Microsoft Windows netbios-ssn<br>Microsoft Windows Active Directory LDAP<br><br><br>Microsoft Windows RPC over HTTP/1.0<br>Microsoft Windows Active Directory LDAP<br>Microsoft Windows Active Directory LDAP<br>Microsoft Windows Active Directory LDAP<br>Microsoft Terminal Services<br>Microsoft HTTPAPI httpd/2.0<br>Microsoft HTTPAPI httpd/2.0                             | windows |
+  | 192.168.56.22  | castelblack.north.sevenkingdoms.local | 80/tcp<br>135/tcp<br>139/tcp<br>445/tcp<br>1433/tcp<br>3389/tcp<br>5985/tcp<br>5986/tcp                                                                             | http<br>msrpc<br>netbios-ssn<br>microsoft-ds<br>ms-sql-s<br>ms-wbt-server<br>http<br>http                                                                          | Microsoft IIS httpd/10.0<br>Microsoft Windows RPC<br>Microsoft Windows netbios-ssn<br><br>Microsoft SQL Server 2019/15.00.2000.00; RTM<br>Microsoft Terminal Services<br>Microsoft HTTPAPI httpd/2.0<br>Microsoft HTTPAPI httpd/2.0                                                                                                                                                                                                                         | windows |
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w nmap --multi-table]
+  '''
+  #!/bin/sh
+  
+  nmap 192.168.56.10 -sS -A -Pn -n -T4 -oA 192.168.56.10 -p 53,80,88,135,139,389,445,464,593,636,3268,3269,3389,5985,5986,5987
+  nmap 192.168.56.11 -sS -A -Pn -n -T4 -oA 192.168.56.11 -p 53,88,135,139,389,445,464,593,636,3268,3269,3389,5985,5986,5987
+  nmap 192.168.56.22 -sS -A -Pn -n -T4 -oA 192.168.56.22 -p 80,135,139,445,1433,3389,5985,5986,5987
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w nmap]
+  '''
+  #!/bin/sh
+  
+  nmap 192.168.56.10 -sS -A -Pn -n -T4 -oA 192.168.56.10 -p 53,80,88,135,139,389,445,464,593,636,3268,3269,3389,5985,5986,5987
+  nmap 192.168.56.11 -sS -A -Pn -n -T4 -oA 192.168.56.11 -p 53,88,135,139,389,445,464,593,636,3268,3269,3389,5985,5986,5987
+  nmap 192.168.56.22 -sS -A -Pn -n -T4 -oA 192.168.56.22 -p 80,135,139,445,1433,3389,5985,5986,5987
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w terminal --multi-table]
+  '''
+  ╒═════════════════╤════════════════════════════════════╤═════════════════════════════════════════╕
+  │ 192.168.56.10   │ kingslanding.sevenkingdoms.local   │ windows                                 │
+  ╞═════════════════╪════════════════════════════════════╪═════════════════════════════════════════╡
+  │ 53/tcp          │ domain                             │ Simple DNS Plus                         │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 80/tcp          │ http                               │ Microsoft IIS httpd/10.0                │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 88/tcp          │ kerberos-sec                       │ Microsoft Windows Kerberos              │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 135/tcp         │ msrpc                              │ Microsoft Windows RPC                   │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 139/tcp         │ netbios-ssn                        │ Microsoft Windows netbios-ssn           │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 389/tcp         │ ldap                               │ Microsoft Windows Active Directory LDAP │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 445/tcp         │ microsoft-ds                       │                                         │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 464/tcp         │ kpasswd5                           │                                         │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 593/tcp         │ ncacn_http                         │ Microsoft Windows RPC over HTTP/1.0     │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 636/tcp         │ ldap                               │ Microsoft Windows Active Directory LDAP │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 3268/tcp        │ ldap                               │ Microsoft Windows Active Directory LDAP │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 3269/tcp        │ ldap                               │ Microsoft Windows Active Directory LDAP │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 3389/tcp        │ ms-wbt-server                      │ Microsoft Terminal Services             │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 5985/tcp        │ http                               │ Microsoft HTTPAPI httpd/2.0             │
+  ├─────────────────┼────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 5986/tcp        │ http                               │ Microsoft HTTPAPI httpd/2.0             │
+  ╘═════════════════╧════════════════════════════════════╧═════════════════════════════════════════╛
+  
+  ╒═════════════════╤════════════════════════════════════════╤═════════════════════════════════════════╕
+  │ 192.168.56.11   │ winterfell.north.sevenkingdoms.local   │ windows                                 │
+  ╞═════════════════╪════════════════════════════════════════╪═════════════════════════════════════════╡
+  │ 53/tcp          │ domain                                 │ Simple DNS Plus                         │
+  ├─────────────────┼────────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 88/tcp          │ kerberos-sec                           │ Microsoft Windows Kerberos              │
+  ├─────────────────┼────────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 135/tcp         │ msrpc                                  │ Microsoft Windows RPC                   │
+  ├─────────────────┼────────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 139/tcp         │ netbios-ssn                            │ Microsoft Windows netbios-ssn           │
+  ├─────────────────┼────────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 389/tcp         │ ldap                                   │ Microsoft Windows Active Directory LDAP │
+  ├─────────────────┼────────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 445/tcp         │ microsoft-ds                           │                                         │
+  ├─────────────────┼────────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 464/tcp         │ kpasswd5                               │                                         │
+  ├─────────────────┼────────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 593/tcp         │ ncacn_http                             │ Microsoft Windows RPC over HTTP/1.0     │
+  ├─────────────────┼────────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 636/tcp         │ ldap                                   │ Microsoft Windows Active Directory LDAP │
+  ├─────────────────┼────────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 3268/tcp        │ ldap                                   │ Microsoft Windows Active Directory LDAP │
+  ├─────────────────┼────────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 3269/tcp        │ ldap                                   │ Microsoft Windows Active Directory LDAP │
+  ├─────────────────┼────────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 3389/tcp        │ ms-wbt-server                          │ Microsoft Terminal Services             │
+  ├─────────────────┼────────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 5985/tcp        │ http                                   │ Microsoft HTTPAPI httpd/2.0             │
+  ├─────────────────┼────────────────────────────────────────┼─────────────────────────────────────────┤
+  │ 5986/tcp        │ http                                   │ Microsoft HTTPAPI httpd/2.0             │
+  ╘═════════════════╧════════════════════════════════════════╧═════════════════════════════════════════╛
+  
+  ╒═════════════════╤═════════════════════════════════════════╤══════════════════════════════════════════════╕
+  │ 192.168.56.22   │ castelblack.north.sevenkingdoms.local   │ windows                                      │
+  ╞═════════════════╪═════════════════════════════════════════╪══════════════════════════════════════════════╡
+  │ 80/tcp          │ http                                    │ Microsoft IIS httpd/10.0                     │
+  ├─────────────────┼─────────────────────────────────────────┼──────────────────────────────────────────────┤
+  │ 135/tcp         │ msrpc                                   │ Microsoft Windows RPC                        │
+  ├─────────────────┼─────────────────────────────────────────┼──────────────────────────────────────────────┤
+  │ 139/tcp         │ netbios-ssn                             │ Microsoft Windows netbios-ssn                │
+  ├─────────────────┼─────────────────────────────────────────┼──────────────────────────────────────────────┤
+  │ 445/tcp         │ microsoft-ds                            │                                              │
+  ├─────────────────┼─────────────────────────────────────────┼──────────────────────────────────────────────┤
+  │ 1433/tcp        │ ms-sql-s                                │ Microsoft SQL Server 2019/15.00.2000.00; RTM │
+  ├─────────────────┼─────────────────────────────────────────┼──────────────────────────────────────────────┤
+  │ 3389/tcp        │ ms-wbt-server                           │ Microsoft Terminal Services                  │
+  ├─────────────────┼─────────────────────────────────────────┼──────────────────────────────────────────────┤
+  │ 5985/tcp        │ http                                    │ Microsoft HTTPAPI httpd/2.0                  │
+  ├─────────────────┼─────────────────────────────────────────┼──────────────────────────────────────────────┤
+  │ 5986/tcp        │ http                                    │ Microsoft HTTPAPI httpd/2.0                  │
+  ╘═════════════════╧═════════════════════════════════════════╧══════════════════════════════════════════════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w terminal]
+  '''
+  ╒════════════════╤═══════════════════════════════════════╤══════════╤═══════════════╤══════════════════════════════════════════════╤═════════╕
+  │ IP-Addresses   │ Hostnames                             │ Ports    │ Services      │ Banners                                      │ OS      │
+  ╞════════════════╪═══════════════════════════════════════╪══════════╪═══════════════╪══════════════════════════════════════════════╪═════════╡
+  │ 192.168.56.10  │ kingslanding.sevenkingdoms.local      │ 53/tcp   │ domain        │ Simple DNS Plus                              │ windows │
+  │                │                                       │ 80/tcp   │ http          │ Microsoft IIS httpd/10.0                     │         │
+  │                │                                       │ 88/tcp   │ kerberos-sec  │ Microsoft Windows Kerberos                   │         │
+  │                │                                       │ 135/tcp  │ msrpc         │ Microsoft Windows RPC                        │         │
+  │                │                                       │ 139/tcp  │ netbios-ssn   │ Microsoft Windows netbios-ssn                │         │
+  │                │                                       │ 389/tcp  │ ldap          │ Microsoft Windows Active Directory LDAP      │         │
+  │                │                                       │ 445/tcp  │ microsoft-ds  │                                              │         │
+  │                │                                       │ 464/tcp  │ kpasswd5      │                                              │         │
+  │                │                                       │ 593/tcp  │ ncacn_http    │ Microsoft Windows RPC over HTTP/1.0          │         │
+  │                │                                       │ 636/tcp  │ ldap          │ Microsoft Windows Active Directory LDAP      │         │
+  │                │                                       │ 3268/tcp │ ldap          │ Microsoft Windows Active Directory LDAP      │         │
+  │                │                                       │ 3269/tcp │ ldap          │ Microsoft Windows Active Directory LDAP      │         │
+  │                │                                       │ 3389/tcp │ ms-wbt-server │ Microsoft Terminal Services                  │         │
+  │                │                                       │ 5985/tcp │ http          │ Microsoft HTTPAPI httpd/2.0                  │         │
+  │                │                                       │ 5986/tcp │ http          │ Microsoft HTTPAPI httpd/2.0                  │         │
+  ├────────────────┼───────────────────────────────────────┼──────────┼───────────────┼──────────────────────────────────────────────┼─────────┤
+  │ 192.168.56.11  │ winterfell.north.sevenkingdoms.local  │ 53/tcp   │ domain        │ Simple DNS Plus                              │ windows │
+  │                │                                       │ 88/tcp   │ kerberos-sec  │ Microsoft Windows Kerberos                   │         │
+  │                │                                       │ 135/tcp  │ msrpc         │ Microsoft Windows RPC                        │         │
+  │                │                                       │ 139/tcp  │ netbios-ssn   │ Microsoft Windows netbios-ssn                │         │
+  │                │                                       │ 389/tcp  │ ldap          │ Microsoft Windows Active Directory LDAP      │         │
+  │                │                                       │ 445/tcp  │ microsoft-ds  │                                              │         │
+  │                │                                       │ 464/tcp  │ kpasswd5      │                                              │         │
+  │                │                                       │ 593/tcp  │ ncacn_http    │ Microsoft Windows RPC over HTTP/1.0          │         │
+  │                │                                       │ 636/tcp  │ ldap          │ Microsoft Windows Active Directory LDAP      │         │
+  │                │                                       │ 3268/tcp │ ldap          │ Microsoft Windows Active Directory LDAP      │         │
+  │                │                                       │ 3269/tcp │ ldap          │ Microsoft Windows Active Directory LDAP      │         │
+  │                │                                       │ 3389/tcp │ ms-wbt-server │ Microsoft Terminal Services                  │         │
+  │                │                                       │ 5985/tcp │ http          │ Microsoft HTTPAPI httpd/2.0                  │         │
+  │                │                                       │ 5986/tcp │ http          │ Microsoft HTTPAPI httpd/2.0                  │         │
+  ├────────────────┼───────────────────────────────────────┼──────────┼───────────────┼──────────────────────────────────────────────┼─────────┤
+  │ 192.168.56.22  │ castelblack.north.sevenkingdoms.local │ 80/tcp   │ http          │ Microsoft IIS httpd/10.0                     │ windows │
+  │                │                                       │ 135/tcp  │ msrpc         │ Microsoft Windows RPC                        │         │
+  │                │                                       │ 139/tcp  │ netbios-ssn   │ Microsoft Windows netbios-ssn                │         │
+  │                │                                       │ 445/tcp  │ microsoft-ds  │                                              │         │
+  │                │                                       │ 1433/tcp │ ms-sql-s      │ Microsoft SQL Server 2019/15.00.2000.00; RTM │         │
+  │                │                                       │ 3389/tcp │ ms-wbt-server │ Microsoft Terminal Services                  │         │
+  │                │                                       │ 5985/tcp │ http          │ Microsoft HTTPAPI httpd/2.0                  │         │
+  │                │                                       │ 5986/tcp │ http          │ Microsoft HTTPAPI httpd/2.0                  │         │
+  ╘════════════════╧═══════════════════════════════════════╧══════════╧═══════════════╧══════════════════════════════════════════════╧═════════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w typst --multi-table]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (3),
+    [*192.168.56.10*], [*kingslanding.sevenkingdoms.local*], [*windows*],
+    [53/tcp], [domain], [Simple DNS Plus],
+    [80/tcp], [http], [Microsoft IIS httpd/10.0],
+    [88/tcp], [kerberos-sec], [Microsoft Windows Kerberos],
+    [135/tcp], [msrpc], [Microsoft Windows RPC],
+    [139/tcp], [netbios-ssn], [Microsoft Windows netbios-ssn],
+    [389/tcp], [ldap], [Microsoft Windows Active Directory LDAP],
+    [445/tcp], [microsoft-ds], [],
+    [464/tcp], [kpasswd5], [],
+    [593/tcp], [ncacn\_http], [Microsoft Windows RPC over HTTP/1.0],
+    [636/tcp], [ldap], [Microsoft Windows Active Directory LDAP],
+    [3268/tcp], [ldap], [Microsoft Windows Active Directory LDAP],
+    [3269/tcp], [ldap], [Microsoft Windows Active Directory LDAP],
+    [3389/tcp], [ms-wbt-server], [Microsoft Terminal Services],
+    [5985/tcp], [http], [Microsoft HTTPAPI httpd/2.0],
+    [5986/tcp], [http], [Microsoft HTTPAPI httpd/2.0]
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [*192.168.56.11*], [*winterfell.north.sevenkingdoms.local*], [*windows*],
+    [53/tcp], [domain], [Simple DNS Plus],
+    [88/tcp], [kerberos-sec], [Microsoft Windows Kerberos],
+    [135/tcp], [msrpc], [Microsoft Windows RPC],
+    [139/tcp], [netbios-ssn], [Microsoft Windows netbios-ssn],
+    [389/tcp], [ldap], [Microsoft Windows Active Directory LDAP],
+    [445/tcp], [microsoft-ds], [],
+    [464/tcp], [kpasswd5], [],
+    [593/tcp], [ncacn\_http], [Microsoft Windows RPC over HTTP/1.0],
+    [636/tcp], [ldap], [Microsoft Windows Active Directory LDAP],
+    [3268/tcp], [ldap], [Microsoft Windows Active Directory LDAP],
+    [3269/tcp], [ldap], [Microsoft Windows Active Directory LDAP],
+    [3389/tcp], [ms-wbt-server], [Microsoft Terminal Services],
+    [5985/tcp], [http], [Microsoft HTTPAPI httpd/2.0],
+    [5986/tcp], [http], [Microsoft HTTPAPI httpd/2.0]
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [*192.168.56.22*], [*castelblack.north.sevenkingdoms.local*], [*windows*],
+    [80/tcp], [http], [Microsoft IIS httpd/10.0],
+    [135/tcp], [msrpc], [Microsoft Windows RPC],
+    [139/tcp], [netbios-ssn], [Microsoft Windows netbios-ssn],
+    [445/tcp], [microsoft-ds], [],
+    [1433/tcp], [ms-sql-s], [Microsoft SQL Server 2019/15.00.2000.00; RTM],
+    [3389/tcp], [ms-wbt-server], [Microsoft Terminal Services],
+    [5985/tcp], [http], [Microsoft HTTPAPI httpd/2.0],
+    [5986/tcp], [http], [Microsoft HTTPAPI httpd/2.0]
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w typst]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (6),
+    [*IP-Addresses*], [*Hostnames*], [*Ports*], [*Services*], [*Banners*], [*OS*],
+    [192.168.56.10], [kingslanding.sevenkingdoms.local], [53/tcp \ 80/tcp \ 88/tcp \ 135/tcp \ 139/tcp \ 389/tcp \ 445/tcp \ 464/tcp \ 593/tcp \ 636/tcp \ 3268/tcp \ 3269/tcp \ 3389/tcp \ 5985/tcp \ 5986/tcp], [domain \ http \ kerberos-sec \ msrpc \ netbios-ssn \ ldap \ microsoft-ds \ kpasswd5 \ ncacn\_http \ ldap \ ldap \ ldap \ ms-wbt-server \ http \ http], [Simple DNS Plus \ Microsoft IIS httpd/10.0 \ Microsoft Windows Kerberos \ Microsoft Windows RPC \ Microsoft Windows netbios-ssn \ Microsoft Windows Active Directory LDAP \  \  \ Microsoft Windows RPC over HTTP/1.0 \ Microsoft Windows Active Directory LDAP \ Microsoft Windows Active Directory LDAP \ Microsoft Windows Active Directory LDAP \ Microsoft Terminal Services \ Microsoft HTTPAPI httpd/2.0 \ Microsoft HTTPAPI httpd/2.0], [windows],
+    [192.168.56.11], [winterfell.north.sevenkingdoms.local], [53/tcp \ 88/tcp \ 135/tcp \ 139/tcp \ 389/tcp \ 445/tcp \ 464/tcp \ 593/tcp \ 636/tcp \ 3268/tcp \ 3269/tcp \ 3389/tcp \ 5985/tcp \ 5986/tcp], [domain \ kerberos-sec \ msrpc \ netbios-ssn \ ldap \ microsoft-ds \ kpasswd5 \ ncacn\_http \ ldap \ ldap \ ldap \ ms-wbt-server \ http \ http], [Simple DNS Plus \ Microsoft Windows Kerberos \ Microsoft Windows RPC \ Microsoft Windows netbios-ssn \ Microsoft Windows Active Directory LDAP \  \  \ Microsoft Windows RPC over HTTP/1.0 \ Microsoft Windows Active Directory LDAP \ Microsoft Windows Active Directory LDAP \ Microsoft Windows Active Directory LDAP \ Microsoft Terminal Services \ Microsoft HTTPAPI httpd/2.0 \ Microsoft HTTPAPI httpd/2.0], [windows],
+    [192.168.56.22], [castelblack.north.sevenkingdoms.local], [80/tcp \ 135/tcp \ 139/tcp \ 445/tcp \ 1433/tcp \ 3389/tcp \ 5985/tcp \ 5986/tcp], [http \ msrpc \ netbios-ssn \ microsoft-ds \ ms-sql-s \ ms-wbt-server \ http \ http], [Microsoft IIS httpd/10.0 \ Microsoft Windows RPC \ Microsoft Windows netbios-ssn \  \ Microsoft SQL Server 2019/15.00.2000.00; RTM \ Microsoft Terminal Services \ Microsoft HTTPAPI httpd/2.0 \ Microsoft HTTPAPI httpd/2.0], [windows]
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w url --multi-table]
+  '''
+  domain://192.168.56.10:53
+  domain://192.168.56.11:53
+  domain://kingslanding.sevenkingdoms.local:53
+  domain://winterfell.north.sevenkingdoms.local:53
+  http://192.168.56.10:5985
+  http://192.168.56.10:5986
+  http://192.168.56.10:80
+  http://192.168.56.11:5985
+  http://192.168.56.11:5986
+  http://192.168.56.22:5985
+  http://192.168.56.22:5986
+  http://192.168.56.22:80
+  http://castelblack.north.sevenkingdoms.local:5985
+  http://castelblack.north.sevenkingdoms.local:5986
+  http://castelblack.north.sevenkingdoms.local:80
+  http://kingslanding.sevenkingdoms.local:5985
+  http://kingslanding.sevenkingdoms.local:5986
+  http://kingslanding.sevenkingdoms.local:80
+  http://winterfell.north.sevenkingdoms.local:5985
+  http://winterfell.north.sevenkingdoms.local:5986
+  kerberos-sec://192.168.56.10:88
+  kerberos-sec://192.168.56.11:88
+  kerberos-sec://kingslanding.sevenkingdoms.local:88
+  kerberos-sec://winterfell.north.sevenkingdoms.local:88
+  kpasswd5://192.168.56.10:464
+  kpasswd5://192.168.56.11:464
+  kpasswd5://kingslanding.sevenkingdoms.local:464
+  kpasswd5://winterfell.north.sevenkingdoms.local:464
+  ldap://192.168.56.10:3268
+  ldap://192.168.56.10:3269
+  ldap://192.168.56.10:389
+  ldap://192.168.56.10:636
+  ldap://192.168.56.11:3268
+  ldap://192.168.56.11:3269
+  ldap://192.168.56.11:389
+  ldap://192.168.56.11:636
+  ldap://kingslanding.sevenkingdoms.local:3268
+  ldap://kingslanding.sevenkingdoms.local:3269
+  ldap://kingslanding.sevenkingdoms.local:389
+  ldap://kingslanding.sevenkingdoms.local:636
+  ldap://winterfell.north.sevenkingdoms.local:3268
+  ldap://winterfell.north.sevenkingdoms.local:3269
+  ldap://winterfell.north.sevenkingdoms.local:389
+  ldap://winterfell.north.sevenkingdoms.local:636
+  microsoft-ds://192.168.56.10:445
+  microsoft-ds://192.168.56.11:445
+  microsoft-ds://192.168.56.22:445
+  microsoft-ds://castelblack.north.sevenkingdoms.local:445
+  microsoft-ds://kingslanding.sevenkingdoms.local:445
+  microsoft-ds://winterfell.north.sevenkingdoms.local:445
+  ms-sql-s://192.168.56.22:1433
+  ms-sql-s://castelblack.north.sevenkingdoms.local:1433
+  ms-wbt-server://192.168.56.10:3389
+  ms-wbt-server://192.168.56.11:3389
+  ms-wbt-server://192.168.56.22:3389
+  ms-wbt-server://castelblack.north.sevenkingdoms.local:3389
+  ms-wbt-server://kingslanding.sevenkingdoms.local:3389
+  ms-wbt-server://winterfell.north.sevenkingdoms.local:3389
+  msrpc://192.168.56.10:135
+  msrpc://192.168.56.11:135
+  msrpc://192.168.56.22:135
+  msrpc://castelblack.north.sevenkingdoms.local:135
+  msrpc://kingslanding.sevenkingdoms.local:135
+  msrpc://winterfell.north.sevenkingdoms.local:135
+  ncacn_http://192.168.56.10:593
+  ncacn_http://192.168.56.11:593
+  ncacn_http://kingslanding.sevenkingdoms.local:593
+  ncacn_http://winterfell.north.sevenkingdoms.local:593
+  netbios-ssn://192.168.56.10:139
+  netbios-ssn://192.168.56.11:139
+  netbios-ssn://192.168.56.22:139
+  netbios-ssn://castelblack.north.sevenkingdoms.local:139
+  netbios-ssn://kingslanding.sevenkingdoms.local:139
+  netbios-ssn://winterfell.north.sevenkingdoms.local:139
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w url]
+  '''
+  domain://192.168.56.10:53
+  domain://192.168.56.11:53
+  domain://kingslanding.sevenkingdoms.local:53
+  domain://winterfell.north.sevenkingdoms.local:53
+  http://192.168.56.10:5985
+  http://192.168.56.10:5986
+  http://192.168.56.10:80
+  http://192.168.56.11:5985
+  http://192.168.56.11:5986
+  http://192.168.56.22:5985
+  http://192.168.56.22:5986
+  http://192.168.56.22:80
+  http://castelblack.north.sevenkingdoms.local:5985
+  http://castelblack.north.sevenkingdoms.local:5986
+  http://castelblack.north.sevenkingdoms.local:80
+  http://kingslanding.sevenkingdoms.local:5985
+  http://kingslanding.sevenkingdoms.local:5986
+  http://kingslanding.sevenkingdoms.local:80
+  http://winterfell.north.sevenkingdoms.local:5985
+  http://winterfell.north.sevenkingdoms.local:5986
+  kerberos-sec://192.168.56.10:88
+  kerberos-sec://192.168.56.11:88
+  kerberos-sec://kingslanding.sevenkingdoms.local:88
+  kerberos-sec://winterfell.north.sevenkingdoms.local:88
+  kpasswd5://192.168.56.10:464
+  kpasswd5://192.168.56.11:464
+  kpasswd5://kingslanding.sevenkingdoms.local:464
+  kpasswd5://winterfell.north.sevenkingdoms.local:464
+  ldap://192.168.56.10:3268
+  ldap://192.168.56.10:3269
+  ldap://192.168.56.10:389
+  ldap://192.168.56.10:636
+  ldap://192.168.56.11:3268
+  ldap://192.168.56.11:3269
+  ldap://192.168.56.11:389
+  ldap://192.168.56.11:636
+  ldap://kingslanding.sevenkingdoms.local:3268
+  ldap://kingslanding.sevenkingdoms.local:3269
+  ldap://kingslanding.sevenkingdoms.local:389
+  ldap://kingslanding.sevenkingdoms.local:636
+  ldap://winterfell.north.sevenkingdoms.local:3268
+  ldap://winterfell.north.sevenkingdoms.local:3269
+  ldap://winterfell.north.sevenkingdoms.local:389
+  ldap://winterfell.north.sevenkingdoms.local:636
+  microsoft-ds://192.168.56.10:445
+  microsoft-ds://192.168.56.11:445
+  microsoft-ds://192.168.56.22:445
+  microsoft-ds://castelblack.north.sevenkingdoms.local:445
+  microsoft-ds://kingslanding.sevenkingdoms.local:445
+  microsoft-ds://winterfell.north.sevenkingdoms.local:445
+  ms-sql-s://192.168.56.22:1433
+  ms-sql-s://castelblack.north.sevenkingdoms.local:1433
+  ms-wbt-server://192.168.56.10:3389
+  ms-wbt-server://192.168.56.11:3389
+  ms-wbt-server://192.168.56.22:3389
+  ms-wbt-server://castelblack.north.sevenkingdoms.local:3389
+  ms-wbt-server://kingslanding.sevenkingdoms.local:3389
+  ms-wbt-server://winterfell.north.sevenkingdoms.local:3389
+  msrpc://192.168.56.10:135
+  msrpc://192.168.56.11:135
+  msrpc://192.168.56.22:135
+  msrpc://castelblack.north.sevenkingdoms.local:135
+  msrpc://kingslanding.sevenkingdoms.local:135
+  msrpc://winterfell.north.sevenkingdoms.local:135
+  ncacn_http://192.168.56.10:593
+  ncacn_http://192.168.56.11:593
+  ncacn_http://kingslanding.sevenkingdoms.local:593
+  ncacn_http://winterfell.north.sevenkingdoms.local:593
+  netbios-ssn://192.168.56.10:139
+  netbios-ssn://192.168.56.11:139
+  netbios-ssn://192.168.56.22:139
+  netbios-ssn://castelblack.north.sevenkingdoms.local:139
+  netbios-ssn://kingslanding.sevenkingdoms.local:139
+  netbios-ssn://winterfell.north.sevenkingdoms.local:139
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w xml --multi-table]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="192.168.56.10">
+      <hostnames>
+        <hostname>kingslanding.sevenkingdoms.local</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="53">
+          <services>
+            <service>domain</service>
+          </services>
+          <banners>
+            <banner>Simple DNS Plus</banner>
+          </banners>
+        </port>
+        <port number="80">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft IIS httpd/10.0</banner>
+          </banners>
+        </port>
+        <port number="88">
+          <services>
+            <service>kerberos-sec</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Kerberos</banner>
+          </banners>
+        </port>
+        <port number="135">
+          <services>
+            <service>msrpc</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows RPC</banner>
+          </banners>
+        </port>
+        <port number="139">
+          <services>
+            <service>netbios-ssn</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows netbios-ssn</banner>
+          </banners>
+        </port>
+        <port number="389">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="445">
+          <services>
+            <service>microsoft-ds</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="464">
+          <services>
+            <service>kpasswd5</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="593">
+          <services>
+            <service>ncacn_http</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows RPC over HTTP/1.0</banner>
+          </banners>
+        </port>
+        <port number="636">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="3268">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="3269">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="3389">
+          <services>
+            <service>ms-wbt-server</service>
+          </services>
+          <banners>
+            <banner>Microsoft Terminal Services</banner>
+          </banners>
+        </port>
+        <port number="5985">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft HTTPAPI httpd/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft HTTPAPI httpd/2.0</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.11">
+      <hostnames>
+        <hostname>winterfell.north.sevenkingdoms.local</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="53">
+          <services>
+            <service>domain</service>
+          </services>
+          <banners>
+            <banner>Simple DNS Plus</banner>
+          </banners>
+        </port>
+        <port number="88">
+          <services>
+            <service>kerberos-sec</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Kerberos</banner>
+          </banners>
+        </port>
+        <port number="135">
+          <services>
+            <service>msrpc</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows RPC</banner>
+          </banners>
+        </port>
+        <port number="139">
+          <services>
+            <service>netbios-ssn</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows netbios-ssn</banner>
+          </banners>
+        </port>
+        <port number="389">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="445">
+          <services>
+            <service>microsoft-ds</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="464">
+          <services>
+            <service>kpasswd5</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="593">
+          <services>
+            <service>ncacn_http</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows RPC over HTTP/1.0</banner>
+          </banners>
+        </port>
+        <port number="636">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="3268">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="3269">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="3389">
+          <services>
+            <service>ms-wbt-server</service>
+          </services>
+          <banners>
+            <banner>Microsoft Terminal Services</banner>
+          </banners>
+        </port>
+        <port number="5985">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft HTTPAPI httpd/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft HTTPAPI httpd/2.0</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.22">
+      <hostnames>
+        <hostname>castelblack.north.sevenkingdoms.local</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="80">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft IIS httpd/10.0</banner>
+          </banners>
+        </port>
+        <port number="135">
+          <services>
+            <service>msrpc</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows RPC</banner>
+          </banners>
+        </port>
+        <port number="139">
+          <services>
+            <service>netbios-ssn</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows netbios-ssn</banner>
+          </banners>
+        </port>
+        <port number="445">
+          <services>
+            <service>microsoft-ds</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="1433">
+          <services>
+            <service>ms-sql-s</service>
+          </services>
+          <banners>
+            <banner>Microsoft SQL Server 2019/15.00.2000.00; RTM</banner>
+          </banners>
+        </port>
+        <port number="3389">
+          <services>
+            <service>ms-wbt-server</service>
+          </services>
+          <banners>
+            <banner>Microsoft Terminal Services</banner>
+          </banners>
+        </port>
+        <port number="5985">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft HTTPAPI httpd/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft HTTPAPI httpd/2.0</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w xml]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="192.168.56.10">
+      <hostnames>
+        <hostname>kingslanding.sevenkingdoms.local</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="53">
+          <services>
+            <service>domain</service>
+          </services>
+          <banners>
+            <banner>Simple DNS Plus</banner>
+          </banners>
+        </port>
+        <port number="80">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft IIS httpd/10.0</banner>
+          </banners>
+        </port>
+        <port number="88">
+          <services>
+            <service>kerberos-sec</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Kerberos</banner>
+          </banners>
+        </port>
+        <port number="135">
+          <services>
+            <service>msrpc</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows RPC</banner>
+          </banners>
+        </port>
+        <port number="139">
+          <services>
+            <service>netbios-ssn</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows netbios-ssn</banner>
+          </banners>
+        </port>
+        <port number="389">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="445">
+          <services>
+            <service>microsoft-ds</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="464">
+          <services>
+            <service>kpasswd5</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="593">
+          <services>
+            <service>ncacn_http</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows RPC over HTTP/1.0</banner>
+          </banners>
+        </port>
+        <port number="636">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="3268">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="3269">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="3389">
+          <services>
+            <service>ms-wbt-server</service>
+          </services>
+          <banners>
+            <banner>Microsoft Terminal Services</banner>
+          </banners>
+        </port>
+        <port number="5985">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft HTTPAPI httpd/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft HTTPAPI httpd/2.0</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.11">
+      <hostnames>
+        <hostname>winterfell.north.sevenkingdoms.local</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="53">
+          <services>
+            <service>domain</service>
+          </services>
+          <banners>
+            <banner>Simple DNS Plus</banner>
+          </banners>
+        </port>
+        <port number="88">
+          <services>
+            <service>kerberos-sec</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Kerberos</banner>
+          </banners>
+        </port>
+        <port number="135">
+          <services>
+            <service>msrpc</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows RPC</banner>
+          </banners>
+        </port>
+        <port number="139">
+          <services>
+            <service>netbios-ssn</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows netbios-ssn</banner>
+          </banners>
+        </port>
+        <port number="389">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="445">
+          <services>
+            <service>microsoft-ds</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="464">
+          <services>
+            <service>kpasswd5</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="593">
+          <services>
+            <service>ncacn_http</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows RPC over HTTP/1.0</banner>
+          </banners>
+        </port>
+        <port number="636">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="3268">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="3269">
+          <services>
+            <service>ldap</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows Active Directory LDAP</banner>
+          </banners>
+        </port>
+        <port number="3389">
+          <services>
+            <service>ms-wbt-server</service>
+          </services>
+          <banners>
+            <banner>Microsoft Terminal Services</banner>
+          </banners>
+        </port>
+        <port number="5985">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft HTTPAPI httpd/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft HTTPAPI httpd/2.0</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.22">
+      <hostnames>
+        <hostname>castelblack.north.sevenkingdoms.local</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="80">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft IIS httpd/10.0</banner>
+          </banners>
+        </port>
+        <port number="135">
+          <services>
+            <service>msrpc</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows RPC</banner>
+          </banners>
+        </port>
+        <port number="139">
+          <services>
+            <service>netbios-ssn</service>
+          </services>
+          <banners>
+            <banner>Microsoft Windows netbios-ssn</banner>
+          </banners>
+        </port>
+        <port number="445">
+          <services>
+            <service>microsoft-ds</service>
+          </services>
+          <banners/>
+        </port>
+        <port number="1433">
+          <services>
+            <service>ms-sql-s</service>
+          </services>
+          <banners>
+            <banner>Microsoft SQL Server 2019/15.00.2000.00; RTM</banner>
+          </banners>
+        </port>
+        <port number="3389">
+          <services>
+            <service>ms-wbt-server</service>
+          </services>
+          <banners>
+            <banner>Microsoft Terminal Services</banner>
+          </banners>
+        </port>
+        <port number="5985">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft HTTPAPI httpd/2.0</banner>
+          </banners>
+        </port>
+        <port number="5986">
+          <services>
+            <service>http</service>
+          </services>
+          <banners>
+            <banner>Microsoft HTTPAPI httpd/2.0</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w yaml --multi-table]
+  '''
+  192.168.56.10:
+      hostnames:
+      - kingslanding.sevenkingdoms.local
+      tcp_ports:
+          53:
+              service_names:
+              - domain
+              banners:
+              - Simple DNS Plus
+          80:
+              service_names:
+              - http
+              banners:
+              - Microsoft IIS httpd/10.0
+          88:
+              service_names:
+              - kerberos-sec
+              banners:
+              - Microsoft Windows Kerberos
+          135:
+              service_names:
+              - msrpc
+              banners:
+              - Microsoft Windows RPC
+          139:
+              service_names:
+              - netbios-ssn
+              banners:
+              - Microsoft Windows netbios-ssn
+          389:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          445:
+              service_names:
+              - microsoft-ds
+              banners:
+              - ''
+          464:
+              service_names:
+              - kpasswd5
+              banners:
+              - ''
+          593:
+              service_names:
+              - ncacn_http
+              banners:
+              - Microsoft Windows RPC over HTTP/1.0
+          636:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          3268:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          3269:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          3389:
+              service_names:
+              - ms-wbt-server
+              banners:
+              - Microsoft Terminal Services
+          5985:
+              service_names:
+              - http
+              banners:
+              - Microsoft HTTPAPI httpd/2.0
+          5986:
+              service_names:
+              - http
+              banners:
+              - Microsoft HTTPAPI httpd/2.0
+      udp_ports: {}
+      os:
+      - windows
+  192.168.56.11:
+      hostnames:
+      - winterfell.north.sevenkingdoms.local
+      tcp_ports:
+          53:
+              service_names:
+              - domain
+              banners:
+              - Simple DNS Plus
+          88:
+              service_names:
+              - kerberos-sec
+              banners:
+              - Microsoft Windows Kerberos
+          135:
+              service_names:
+              - msrpc
+              banners:
+              - Microsoft Windows RPC
+          139:
+              service_names:
+              - netbios-ssn
+              banners:
+              - Microsoft Windows netbios-ssn
+          389:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          445:
+              service_names:
+              - microsoft-ds
+              banners:
+              - ''
+          464:
+              service_names:
+              - kpasswd5
+              banners:
+              - ''
+          593:
+              service_names:
+              - ncacn_http
+              banners:
+              - Microsoft Windows RPC over HTTP/1.0
+          636:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          3268:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          3269:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          3389:
+              service_names:
+              - ms-wbt-server
+              banners:
+              - Microsoft Terminal Services
+          5985:
+              service_names:
+              - http
+              banners:
+              - Microsoft HTTPAPI httpd/2.0
+          5986:
+              service_names:
+              - http
+              banners:
+              - Microsoft HTTPAPI httpd/2.0
+      udp_ports: {}
+      os:
+      - windows
+  192.168.56.22:
+      hostnames:
+      - castelblack.north.sevenkingdoms.local
+      tcp_ports:
+          80:
+              service_names:
+              - http
+              banners:
+              - Microsoft IIS httpd/10.0
+          135:
+              service_names:
+              - msrpc
+              banners:
+              - Microsoft Windows RPC
+          139:
+              service_names:
+              - netbios-ssn
+              banners:
+              - Microsoft Windows netbios-ssn
+          445:
+              service_names:
+              - microsoft-ds
+              banners:
+              - ''
+          1433:
+              service_names:
+              - ms-sql-s
+              banners:
+              - Microsoft SQL Server 2019/15.00.2000.00; RTM
+          3389:
+              service_names:
+              - ms-wbt-server
+              banners:
+              - Microsoft Terminal Services
+          5985:
+              service_names:
+              - http
+              banners:
+              - Microsoft HTTPAPI httpd/2.0
+          5986:
+              service_names:
+              - http
+              banners:
+              - Microsoft HTTPAPI httpd/2.0
+      udp_ports: {}
+      os:
+      - windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nmap tests/data/nmap/goad-light.xml -w yaml]
+  '''
+  192.168.56.10:
+      hostnames:
+      - kingslanding.sevenkingdoms.local
+      tcp_ports:
+          53:
+              service_names:
+              - domain
+              banners:
+              - Simple DNS Plus
+          80:
+              service_names:
+              - http
+              banners:
+              - Microsoft IIS httpd/10.0
+          88:
+              service_names:
+              - kerberos-sec
+              banners:
+              - Microsoft Windows Kerberos
+          135:
+              service_names:
+              - msrpc
+              banners:
+              - Microsoft Windows RPC
+          139:
+              service_names:
+              - netbios-ssn
+              banners:
+              - Microsoft Windows netbios-ssn
+          389:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          445:
+              service_names:
+              - microsoft-ds
+              banners:
+              - ''
+          464:
+              service_names:
+              - kpasswd5
+              banners:
+              - ''
+          593:
+              service_names:
+              - ncacn_http
+              banners:
+              - Microsoft Windows RPC over HTTP/1.0
+          636:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          3268:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          3269:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          3389:
+              service_names:
+              - ms-wbt-server
+              banners:
+              - Microsoft Terminal Services
+          5985:
+              service_names:
+              - http
+              banners:
+              - Microsoft HTTPAPI httpd/2.0
+          5986:
+              service_names:
+              - http
+              banners:
+              - Microsoft HTTPAPI httpd/2.0
+      udp_ports: {}
+      os:
+      - windows
+  192.168.56.11:
+      hostnames:
+      - winterfell.north.sevenkingdoms.local
+      tcp_ports:
+          53:
+              service_names:
+              - domain
+              banners:
+              - Simple DNS Plus
+          88:
+              service_names:
+              - kerberos-sec
+              banners:
+              - Microsoft Windows Kerberos
+          135:
+              service_names:
+              - msrpc
+              banners:
+              - Microsoft Windows RPC
+          139:
+              service_names:
+              - netbios-ssn
+              banners:
+              - Microsoft Windows netbios-ssn
+          389:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          445:
+              service_names:
+              - microsoft-ds
+              banners:
+              - ''
+          464:
+              service_names:
+              - kpasswd5
+              banners:
+              - ''
+          593:
+              service_names:
+              - ncacn_http
+              banners:
+              - Microsoft Windows RPC over HTTP/1.0
+          636:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          3268:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          3269:
+              service_names:
+              - ldap
+              banners:
+              - Microsoft Windows Active Directory LDAP
+          3389:
+              service_names:
+              - ms-wbt-server
+              banners:
+              - Microsoft Terminal Services
+          5985:
+              service_names:
+              - http
+              banners:
+              - Microsoft HTTPAPI httpd/2.0
+          5986:
+              service_names:
+              - http
+              banners:
+              - Microsoft HTTPAPI httpd/2.0
+      udp_ports: {}
+      os:
+      - windows
+  192.168.56.22:
+      hostnames:
+      - castelblack.north.sevenkingdoms.local
+      tcp_ports:
+          80:
+              service_names:
+              - http
+              banners:
+              - Microsoft IIS httpd/10.0
+          135:
+              service_names:
+              - msrpc
+              banners:
+              - Microsoft Windows RPC
+          139:
+              service_names:
+              - netbios-ssn
+              banners:
+              - Microsoft Windows netbios-ssn
+          445:
+              service_names:
+              - microsoft-ds
+              banners:
+              - ''
+          1433:
+              service_names:
+              - ms-sql-s
+              banners:
+              - Microsoft SQL Server 2019/15.00.2000.00; RTM
+          3389:
+              service_names:
+              - ms-wbt-server
+              banners:
+              - Microsoft Terminal Services
+          5985:
+              service_names:
+              - http
+              banners:
+              - Microsoft HTTPAPI httpd/2.0
+          5986:
+              service_names:
+              - http
+              banners:
+              - Microsoft HTTPAPI httpd/2.0
+      udp_ports: {}
+      os:
+      - windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/ipv6/nxc/smb.db -w terminal]
+  '''
+  ╒════════════════╤══════════════╤═════════╤════════════╤═══════════════════════╤══════╕
+  │ IP-Addresses   │ Hostnames    │ Ports   │ Services   │ Banners               │ OS   │
+  ╞════════════════╪══════════════╪═════════╪════════════╪═══════════════════════╪══════╡
+  │ 2001:db8:1::10 │ df31357d4ba1 │ 445/tcp │ smb        │ SMB Signing disabled! │      │
+  ╘════════════════╧══════════════╧═════════╧════════════╧═══════════════════════╧══════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w aquatone --multi-table]
+  '''
+  http://192.168.56.10:445
+  http://192.168.56.11:445
+  http://192.168.56.22:445
+  http://castelblack:445
+  http://kingslanding:445
+  http://winterfell:445
+  https://192.168.56.10:445
+  https://192.168.56.11:445
+  https://192.168.56.22:445
+  https://castelblack:445
+  https://kingslanding:445
+  https://winterfell:445
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w aquatone]
+  '''
+  http://192.168.56.10:445
+  http://192.168.56.11:445
+  http://192.168.56.22:445
+  http://castelblack:445
+  http://kingslanding:445
+  http://winterfell:445
+  https://192.168.56.10:445
+  https://192.168.56.11:445
+  https://192.168.56.22:445
+  https://castelblack:445
+  https://kingslanding:445
+  https://winterfell:445
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w csv --multi-table]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  192.168.56.10,kingslanding,445/tcp,smb,,windows
+  192.168.56.11,winterfell,445/tcp,smb,,windows
+  192.168.56.22,castelblack,445/tcp,smb,SMB Signing disabled!,windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w csv]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  192.168.56.10,kingslanding,445/tcp,smb,,windows
+  192.168.56.11,winterfell,445/tcp,smb,,windows
+  192.168.56.22,castelblack,445/tcp,smb,SMB Signing disabled!,windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w host --multi-table]
+  '''
+  192.168.56.10
+  192.168.56.11
+  192.168.56.22
+  castelblack
+  kingslanding
+  winterfell
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w host]
+  '''
+  192.168.56.10
+  192.168.56.11
+  192.168.56.22
+  castelblack
+  kingslanding
+  winterfell
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w html --multi-table]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.10</th>
+        <th>kingslanding</th>
+        <th>windows</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>445/tcp</td>
+        <td>smb</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.11</th>
+        <th>winterfell</th>
+        <th>windows</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>445/tcp</td>
+        <td>smb</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.22</th>
+        <th>castelblack</th>
+        <th>windows</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>445/tcp</td>
+        <td>smb</td>
+        <td>SMB Signing disabled!</td>
+      </tr>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w html]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>IP-Addresses</th>
+        <th>Hostnames</th>
+        <th>Ports</th>
+        <th>Services</th>
+        <th>Banners</th>
+        <th>OS</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>192.168.56.10</td>
+        <td>kingslanding</td>
+        <td>445/tcp</td>
+        <td>smb</td>
+        <td></td>
+        <td>windows</td>
+      </tr>
+      <tr>
+        <td>192.168.56.11</td>
+        <td>winterfell</td>
+        <td>445/tcp</td>
+        <td>smb</td>
+        <td></td>
+        <td>windows</td>
+      </tr>
+      <tr>
+        <td>192.168.56.22</td>
+        <td>castelblack</td>
+        <td>445/tcp</td>
+        <td>smb</td>
+        <td>SMB Signing disabled!</td>
+        <td>windows</td>
+      </tr>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w json --multi-table]
+  '''
+  {"192.168.56.10":{"hostnames":["kingslanding"],"tcp_ports":{"445":{"service_names":["smb"],"banners":[""]}},"udp_ports":{},"os":["windows"]},"192.168.56.11":{"hostnames":["winterfell"],"tcp_ports":{"445":{"service_names":["smb"],"banners":[""]}},"udp_ports":{},"os":["windows"]},"192.168.56.22":{"hostnames":["castelblack"],"tcp_ports":{"445":{"service_names":["smb"],"banners":["SMB Signing disabled!"]}},"udp_ports":{},"os":["windows"]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w json]
+  '''
+  {"192.168.56.10":{"hostnames":["kingslanding"],"tcp_ports":{"445":{"service_names":["smb"],"banners":[""]}},"udp_ports":{},"os":["windows"]},"192.168.56.11":{"hostnames":["winterfell"],"tcp_ports":{"445":{"service_names":["smb"],"banners":[""]}},"udp_ports":{},"os":["windows"]},"192.168.56.22":{"hostnames":["castelblack"],"tcp_ports":{"445":{"service_names":["smb"],"banners":["SMB Signing disabled!"]}},"udp_ports":{},"os":["windows"]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w latex --multi-table]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.10} & \makecell[l]{kingslanding} & \makecell[l]{windows} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.10} & \makecell[l]{kingslanding} & \makecell[l]{windows} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{445/tcp} & \makecell[l]{smb} & \makecell[l]{} \\
+  \end{longtable}
+  
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.11} & \makecell[l]{winterfell} & \makecell[l]{windows} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.11} & \makecell[l]{winterfell} & \makecell[l]{windows} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{445/tcp} & \makecell[l]{smb} & \makecell[l]{} \\
+  \end{longtable}
+  
+  
+  \begin{longtable}{lll}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.22} & \makecell[l]{castelblack} & \makecell[l]{windows} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.22} & \makecell[l]{castelblack} & \makecell[l]{windows} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{3}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{445/tcp} & \makecell[l]{smb} & \makecell[l]{SMB Signing disabled!} \\
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w latex]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{llllll}
+  \caption{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{6}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{192.168.56.10} & \makecell[l]{kingslanding} & \makecell[l]{445/tcp} & \makecell[l]{smb} & \makecell[l]{} & \makecell[l]{windows} \\
+  \makecell[l]{192.168.56.11} & \makecell[l]{winterfell} & \makecell[l]{445/tcp} & \makecell[l]{smb} & \makecell[l]{} & \makecell[l]{windows} \\
+  \makecell[l]{192.168.56.22} & \makecell[l]{castelblack} & \makecell[l]{445/tcp} & \makecell[l]{smb} & \makecell[l]{SMB Signing disabled!} & \makecell[l]{windows} \\
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w markdown --multi-table]
+  '''
+  | 192.168.56.10   | kingslanding   | windows   |
+  |:----------------|:---------------|:----------|
+  | 445/tcp         | smb            |           |
+  
+  
+  | 192.168.56.11   | winterfell   | windows   |
+  |:----------------|:-------------|:----------|
+  | 445/tcp         | smb          |           |
+  
+  
+  | 192.168.56.22   | castelblack   | windows               |
+  |:----------------|:--------------|:----------------------|
+  | 445/tcp         | smb           | SMB Signing disabled! |
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w markdown]
+  '''
+  | IP-Addresses   | Hostnames    | Ports   | Services   | Banners               | OS      |
+  |:---------------|:-------------|:--------|:-----------|:----------------------|:--------|
+  | 192.168.56.10  | kingslanding | 445/tcp | smb        |                       | windows |
+  | 192.168.56.11  | winterfell   | 445/tcp | smb        |                       | windows |
+  | 192.168.56.22  | castelblack  | 445/tcp | smb        | SMB Signing disabled! | windows |
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w nmap --multi-table]
+  '''
+  #!/bin/sh
+  
+  nmap 192.168.56.10 -sS -A -Pn -n -T4 -oA 192.168.56.10 -p 445,446
+  nmap 192.168.56.11 -sS -A -Pn -n -T4 -oA 192.168.56.11 -p 445,446
+  nmap 192.168.56.22 -sS -A -Pn -n -T4 -oA 192.168.56.22 -p 445,446
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w nmap]
+  '''
+  #!/bin/sh
+  
+  nmap 192.168.56.10 -sS -A -Pn -n -T4 -oA 192.168.56.10 -p 445,446
+  nmap 192.168.56.11 -sS -A -Pn -n -T4 -oA 192.168.56.11 -p 445,446
+  nmap 192.168.56.22 -sS -A -Pn -n -T4 -oA 192.168.56.22 -p 445,446
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w terminal --multi-table]
+  '''
+  ╒═════════════════╤════════════════╤═══════════╕
+  │ 192.168.56.10   │ kingslanding   │ windows   │
+  ╞═════════════════╪════════════════╪═══════════╡
+  │ 445/tcp         │ smb            │           │
+  ╘═════════════════╧════════════════╧═══════════╛
+  
+  ╒═════════════════╤══════════════╤═══════════╕
+  │ 192.168.56.11   │ winterfell   │ windows   │
+  ╞═════════════════╪══════════════╪═══════════╡
+  │ 445/tcp         │ smb          │           │
+  ╘═════════════════╧══════════════╧═══════════╛
+  
+  ╒═════════════════╤═══════════════╤═══════════════════════╕
+  │ 192.168.56.22   │ castelblack   │ windows               │
+  ╞═════════════════╪═══════════════╪═══════════════════════╡
+  │ 445/tcp         │ smb           │ SMB Signing disabled! │
+  ╘═════════════════╧═══════════════╧═══════════════════════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w terminal]
+  '''
+  ╒════════════════╤══════════════╤═════════╤════════════╤═══════════════════════╤═════════╕
+  │ IP-Addresses   │ Hostnames    │ Ports   │ Services   │ Banners               │ OS      │
+  ╞════════════════╪══════════════╪═════════╪════════════╪═══════════════════════╪═════════╡
+  │ 192.168.56.10  │ kingslanding │ 445/tcp │ smb        │                       │ windows │
+  ├────────────────┼──────────────┼─────────┼────────────┼───────────────────────┼─────────┤
+  │ 192.168.56.11  │ winterfell   │ 445/tcp │ smb        │                       │ windows │
+  ├────────────────┼──────────────┼─────────┼────────────┼───────────────────────┼─────────┤
+  │ 192.168.56.22  │ castelblack  │ 445/tcp │ smb        │ SMB Signing disabled! │ windows │
+  ╘════════════════╧══════════════╧═════════╧════════════╧═══════════════════════╧═════════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w typst --multi-table]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (3),
+    [*192.168.56.10*], [*kingslanding*], [*windows*],
+    [445/tcp], [smb], []
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [*192.168.56.11*], [*winterfell*], [*windows*],
+    [445/tcp], [smb], []
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [*192.168.56.22*], [*castelblack*], [*windows*],
+    [445/tcp], [smb], [SMB Signing disabled!]
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w typst]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (6),
+    [*IP-Addresses*], [*Hostnames*], [*Ports*], [*Services*], [*Banners*], [*OS*],
+    [192.168.56.10], [kingslanding], [445/tcp], [smb], [], [windows],
+    [192.168.56.11], [winterfell], [445/tcp], [smb], [], [windows],
+    [192.168.56.22], [castelblack], [445/tcp], [smb], [SMB Signing disabled!], [windows]
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w url --multi-table]
+  '''
+  smb://192.168.56.10:445
+  smb://192.168.56.11:445
+  smb://192.168.56.22:445
+  smb://castelblack:445
+  smb://kingslanding:445
+  smb://winterfell:445
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w url]
+  '''
+  smb://192.168.56.10:445
+  smb://192.168.56.11:445
+  smb://192.168.56.22:445
+  smb://castelblack:445
+  smb://kingslanding:445
+  smb://winterfell:445
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w xml --multi-table]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="192.168.56.10">
+      <hostnames>
+        <hostname>kingslanding</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="445">
+          <services>
+            <service>smb</service>
+          </services>
+          <banners/>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.11">
+      <hostnames>
+        <hostname>winterfell</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="445">
+          <services>
+            <service>smb</service>
+          </services>
+          <banners/>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.22">
+      <hostnames>
+        <hostname>castelblack</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="445">
+          <services>
+            <service>smb</service>
+          </services>
+          <banners>
+            <banner>SMB Signing disabled!</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w xml]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="192.168.56.10">
+      <hostnames>
+        <hostname>kingslanding</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="445">
+          <services>
+            <service>smb</service>
+          </services>
+          <banners/>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.11">
+      <hostnames>
+        <hostname>winterfell</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="445">
+          <services>
+            <service>smb</service>
+          </services>
+          <banners/>
+        </port>
+      </tcp_ports>
+    </host>
+    <host ip="192.168.56.22">
+      <hostnames>
+        <hostname>castelblack</hostname>
+      </hostnames>
+      <os_info>
+        <os>windows</os>
+      </os_info>
+      <tcp_ports>
+        <port number="445">
+          <services>
+            <service>smb</service>
+          </services>
+          <banners>
+            <banner>SMB Signing disabled!</banner>
+          </banners>
+        </port>
+      </tcp_ports>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w yaml --multi-table]
+  '''
+  192.168.56.10:
+      hostnames:
+      - kingslanding
+      tcp_ports:
+          445:
+              service_names:
+              - smb
+              banners:
+              - ''
+      udp_ports: {}
+      os:
+      - windows
+  192.168.56.11:
+      hostnames:
+      - winterfell
+      tcp_ports:
+          445:
+              service_names:
+              - smb
+              banners:
+              - ''
+      udp_ports: {}
+      os:
+      - windows
+  192.168.56.22:
+      hostnames:
+      - castelblack
+      tcp_ports:
+          445:
+              service_names:
+              - smb
+              banners:
+              - SMB Signing disabled!
+      udp_ports: {}
+      os:
+      - windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--nxc tests/data/nxc/goad-light-smb.db -w yaml]
+  '''
+  192.168.56.10:
+      hostnames:
+      - kingslanding
+      tcp_ports:
+          445:
+              service_names:
+              - smb
+              banners:
+              - ''
+      udp_ports: {}
+      os:
+      - windows
+  192.168.56.11:
+      hostnames:
+      - winterfell
+      tcp_ports:
+          445:
+              service_names:
+              - smb
+              banners:
+              - ''
+      udp_ports: {}
+      os:
+      - windows
+  192.168.56.22:
+      hostnames:
+      - castelblack
+      tcp_ports:
+          445:
+              service_names:
+              - smb
+              banners:
+              - SMB Signing disabled!
+      udp_ports: {}
+      os:
+      - windows
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/ipv6/txt/txt.txt -w terminal]
+  '''
+  ╒══════════════════════════╤═════════════╤═════════╤════════════╤═══════════╤══════╕
+  │ IP-Addresses             │ Hostnames   │ Ports   │ Services   │ Banners   │ OS   │
+  ╞══════════════════════════╪═════════════╪═════════╪════════════╪═══════════╪══════╡
+  │ 172.217.18.14            │ hostb.com   │         │            │           │      │
+  ├──────────────────────────┼─────────────┼─────────┼────────────┼───────────┼──────┤
+  │ 2a00:1450:4001:80b::200e │ hosta.com   │         │            │           │      │
+  ╘══════════════════════════╧═════════════╧═════════╧════════════╧═══════════╧══════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w aquatone --multi-table]
+  '''
+  http://192.168.56.10
+  http://192.168.56.11
+  http://192.168.56.22
+  http://castelblack.north.sevenkingdoms.local
+  http://kingslanding.sevenkingdoms.local
+  http://winterfell.north.sevenkingdoms.local
+  https://192.168.56.10
+  https://192.168.56.11
+  https://192.168.56.22
+  https://castelblack.north.sevenkingdoms.local
+  https://kingslanding.sevenkingdoms.local
+  https://winterfell.north.sevenkingdoms.local
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w aquatone]
+  '''
+  http://192.168.56.10
+  http://192.168.56.11
+  http://192.168.56.22
+  http://castelblack.north.sevenkingdoms.local
+  http://kingslanding.sevenkingdoms.local
+  http://winterfell.north.sevenkingdoms.local
+  https://192.168.56.10
+  https://192.168.56.11
+  https://192.168.56.22
+  https://castelblack.north.sevenkingdoms.local
+  https://kingslanding.sevenkingdoms.local
+  https://winterfell.north.sevenkingdoms.local
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w csv --multi-table]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  192.168.56.10,kingslanding.sevenkingdoms.local,,,,
+  192.168.56.11,winterfell.north.sevenkingdoms.local,,,,
+  192.168.56.22,castelblack.north.sevenkingdoms.local,,,,
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w csv]
+  '''
+  IP-Addresses,Hostnames,Ports,Services,Banners,OS
+  192.168.56.10,kingslanding.sevenkingdoms.local,,,,
+  192.168.56.11,winterfell.north.sevenkingdoms.local,,,,
+  192.168.56.22,castelblack.north.sevenkingdoms.local,,,,
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w host --multi-table]
+  '''
+  192.168.56.10
+  192.168.56.11
+  192.168.56.22
+  castelblack.north.sevenkingdoms.local
+  kingslanding.sevenkingdoms.local
+  winterfell.north.sevenkingdoms.local
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w host]
+  '''
+  192.168.56.10
+  192.168.56.11
+  192.168.56.22
+  castelblack.north.sevenkingdoms.local
+  kingslanding.sevenkingdoms.local
+  winterfell.north.sevenkingdoms.local
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w html --multi-table]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.10</th>
+        <th>kingslanding.sevenkingdoms.local</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.11</th>
+        <th>winterfell.north.sevenkingdoms.local</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table></div>
+  <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>192.168.56.22</th>
+        <th>castelblack.north.sevenkingdoms.local</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w html]
+  '''
+  
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>scans2any</title>
+              <style>
+                  .table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+                  .table th, .table td { padding: 8px; text-align: left; border: 1px solid #ddd; }
+                  .table-striped tbody tr:nth-of-type(odd) { background-color: #f9f9f9; }
+                  .table-hover tbody tr:hover { background-color: #f5f5f5; }
+                  .container { margin-bottom: 30px; }
+              </style>
+          </head>
+          <body>
+              <h1>scans2any</h1>
+              <div class="container"><table border="1" class="dataframe table table-striped table-hover">
+    <thead>
+      <tr style="text-align: right;">
+        <th>IP-Addresses</th>
+        <th>Hostnames</th>
+        <th>Ports</th>
+        <th>Services</th>
+        <th>Banners</th>
+        <th>OS</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>192.168.56.10</td>
+        <td>kingslanding.sevenkingdoms.local</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>192.168.56.11</td>
+        <td>winterfell.north.sevenkingdoms.local</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>192.168.56.22</td>
+        <td>castelblack.north.sevenkingdoms.local</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table></div>
+          </body>
+          </html>
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w json --multi-table]
+  '''
+  {"192.168.56.10":{"hostnames":["kingslanding.sevenkingdoms.local"],"tcp_ports":{},"udp_ports":{},"os":[]},"192.168.56.11":{"hostnames":["winterfell.north.sevenkingdoms.local"],"tcp_ports":{},"udp_ports":{},"os":[]},"192.168.56.22":{"hostnames":["castelblack.north.sevenkingdoms.local"],"tcp_ports":{},"udp_ports":{},"os":[]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w json]
+  '''
+  {"192.168.56.10":{"hostnames":["kingslanding.sevenkingdoms.local"],"tcp_ports":{},"udp_ports":{},"os":[]},"192.168.56.11":{"hostnames":["winterfell.north.sevenkingdoms.local"],"tcp_ports":{},"udp_ports":{},"os":[]},"192.168.56.22":{"hostnames":["castelblack.north.sevenkingdoms.local"],"tcp_ports":{},"udp_ports":{},"os":[]}}
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w latex --multi-table]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{rrr}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.10} & \makecell[l]{kingslanding.sevenkingdoms.local} & \makecell[l]{} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.10} & \makecell[l]{kingslanding.sevenkingdoms.local} & \makecell[l]{} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{0}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \end{longtable}
+  
+  
+  \begin{longtable}{rrr}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.11} & \makecell[l]{winterfell.north.sevenkingdoms.local} & \makecell[l]{} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.11} & \makecell[l]{winterfell.north.sevenkingdoms.local} & \makecell[l]{} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{0}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \end{longtable}
+  
+  
+  \begin{longtable}{rrr}
+  \caption{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.22} & \makecell[l]{castelblack.north.sevenkingdoms.local} & \makecell[l]{} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Host Information} \\
+  \toprule
+  \makecell[l]{192.168.56.22} & \makecell[l]{castelblack.north.sevenkingdoms.local} & \makecell[l]{} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{0}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w latex]
+  '''
+  \documentclass{article}
+  \usepackage[utf8]{inputenc}
+  \usepackage{longtable}
+  \usepackage{booktabs}
+  \usepackage{geometry}
+  \geometry{a4paper, margin=2pt, landscape}
+  \usepackage{makecell}
+  \usepackage{array}
+  \usepackage{multirow}
+  \title{Infrastructure Scan Results}
+  \author{Generated by scans2any}
+  \date{\today}
+  
+  \begin{document}
+  \maketitle
+  
+  \begin{longtable}{llllll}
+  \caption{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endfirsthead
+  \caption[]{Infrastructure Scan Results} \\
+  \toprule
+  \makecell[l]{IP-Addresses} & \makecell[l]{Hostnames} & \makecell[l]{Ports} & \makecell[l]{Services} & \makecell[l]{Banners} & \makecell[l]{OS} \\
+  \midrule
+  \endhead
+  \midrule
+  \multicolumn{6}{r}{Continued on next page} \\
+  \midrule
+  \endfoot
+  \bottomrule
+  \endlastfoot
+  \makecell[l]{192.168.56.10} & \makecell[l]{kingslanding.sevenkingdoms.local} & \makecell[l]{} & \makecell[l]{} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{192.168.56.11} & \makecell[l]{winterfell.north.sevenkingdoms.local} & \makecell[l]{} & \makecell[l]{} & \makecell[l]{} & \makecell[l]{} \\
+  \makecell[l]{192.168.56.22} & \makecell[l]{castelblack.north.sevenkingdoms.local} & \makecell[l]{} & \makecell[l]{} & \makecell[l]{} & \makecell[l]{} \\
+  \end{longtable}
+  
+  \end{document}
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w markdown --multi-table]
+  '''
+  | 192.168.56.10   | kingslanding.sevenkingdoms.local   |    |
+  |-----------------|------------------------------------|----|
+  
+  
+  | 192.168.56.11   | winterfell.north.sevenkingdoms.local   |    |
+  |-----------------|----------------------------------------|----|
+  
+  
+  | 192.168.56.22   | castelblack.north.sevenkingdoms.local   |    |
+  |-----------------|-----------------------------------------|----|
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w markdown]
+  '''
+  | IP-Addresses   | Hostnames                             | Ports   | Services   | Banners   | OS   |
+  |:---------------|:--------------------------------------|:--------|:-----------|:----------|:-----|
+  | 192.168.56.10  | kingslanding.sevenkingdoms.local      |         |            |           |      |
+  | 192.168.56.11  | winterfell.north.sevenkingdoms.local  |         |            |           |      |
+  | 192.168.56.22  | castelblack.north.sevenkingdoms.local |         |            |           |      |
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w nmap --multi-table]
+  '''
+  #!/bin/sh
+  
+  nmap 192.168.56.10 -sS -A -Pn -n -T4 -oA 192.168.56.10 --top-ports 1000
+  nmap 192.168.56.11 -sS -A -Pn -n -T4 -oA 192.168.56.11 --top-ports 1000
+  nmap 192.168.56.22 -sS -A -Pn -n -T4 -oA 192.168.56.22 --top-ports 1000
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w nmap]
+  '''
+  #!/bin/sh
+  
+  nmap 192.168.56.10 -sS -A -Pn -n -T4 -oA 192.168.56.10 --top-ports 1000
+  nmap 192.168.56.11 -sS -A -Pn -n -T4 -oA 192.168.56.11 --top-ports 1000
+  nmap 192.168.56.22 -sS -A -Pn -n -T4 -oA 192.168.56.22 --top-ports 1000
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w terminal --multi-table]
+  '''
+  ╒═════════════════╤════════════════════════════════════╤════╕
+  │ 192.168.56.10   │ kingslanding.sevenkingdoms.local   │    │
+  ╞═════════════════╪════════════════════════════════════╪════╡
+  ╘═════════════════╧════════════════════════════════════╧════╛
+  
+  ╒═════════════════╤════════════════════════════════════════╤════╕
+  │ 192.168.56.11   │ winterfell.north.sevenkingdoms.local   │    │
+  ╞═════════════════╪════════════════════════════════════════╪════╡
+  ╘═════════════════╧════════════════════════════════════════╧════╛
+  
+  ╒═════════════════╤═════════════════════════════════════════╤════╕
+  │ 192.168.56.22   │ castelblack.north.sevenkingdoms.local   │    │
+  ╞═════════════════╪═════════════════════════════════════════╪════╡
+  ╘═════════════════╧═════════════════════════════════════════╧════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w terminal]
+  '''
+  ╒════════════════╤═══════════════════════════════════════╤═════════╤════════════╤═══════════╤══════╕
+  │ IP-Addresses   │ Hostnames                             │ Ports   │ Services   │ Banners   │ OS   │
+  ╞════════════════╪═══════════════════════════════════════╪═════════╪════════════╪═══════════╪══════╡
+  │ 192.168.56.10  │ kingslanding.sevenkingdoms.local      │         │            │           │      │
+  ├────────────────┼───────────────────────────────────────┼─────────┼────────────┼───────────┼──────┤
+  │ 192.168.56.11  │ winterfell.north.sevenkingdoms.local  │         │            │           │      │
+  ├────────────────┼───────────────────────────────────────┼─────────┼────────────┼───────────┼──────┤
+  │ 192.168.56.22  │ castelblack.north.sevenkingdoms.local │         │            │           │      │
+  ╘════════════════╧═══════════════════════════════════════╧═════════╧════════════╧═══════════╧══════╛
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w typst --multi-table]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (3),
+    [*192.168.56.10*], [*kingslanding.sevenkingdoms.local*], [**],
+    
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [*192.168.56.11*], [*winterfell.north.sevenkingdoms.local*], [**],
+    
+  )
+  
+  #pagebreak()
+  
+  #table(
+    columns: (3),
+    [*192.168.56.22*], [*castelblack.north.sevenkingdoms.local*], [**],
+    
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w typst]
+  '''
+  #set page(flipped: true)
+  
+  #table(
+    columns: (6),
+    [*IP-Addresses*], [*Hostnames*], [*Ports*], [*Services*], [*Banners*], [*OS*],
+    [192.168.56.10], [kingslanding.sevenkingdoms.local], [], [], [], [],
+    [192.168.56.11], [winterfell.north.sevenkingdoms.local], [], [], [], [],
+    [192.168.56.22], [castelblack.north.sevenkingdoms.local], [], [], [], []
+  )
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w url --multi-table]
+  '''
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w url]
+  '''
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w xml --multi-table]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="192.168.56.10">
+      <hostnames>
+        <hostname>kingslanding.sevenkingdoms.local</hostname>
+      </hostnames>
+    </host>
+    <host ip="192.168.56.11">
+      <hostnames>
+        <hostname>winterfell.north.sevenkingdoms.local</hostname>
+      </hostnames>
+    </host>
+    <host ip="192.168.56.22">
+      <hostnames>
+        <hostname>castelblack.north.sevenkingdoms.local</hostname>
+      </hostnames>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w xml]
+  '''
+  <?xml version="1.0" ?>
+  <infrastructure>
+    <host ip="192.168.56.10">
+      <hostnames>
+        <hostname>kingslanding.sevenkingdoms.local</hostname>
+      </hostnames>
+    </host>
+    <host ip="192.168.56.11">
+      <hostnames>
+        <hostname>winterfell.north.sevenkingdoms.local</hostname>
+      </hostnames>
+    </host>
+    <host ip="192.168.56.22">
+      <hostnames>
+        <hostname>castelblack.north.sevenkingdoms.local</hostname>
+      </hostnames>
+    </host>
+  </infrastructure>
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w yaml --multi-table]
+  '''
+  192.168.56.10:
+      hostnames:
+      - kingslanding.sevenkingdoms.local
+      tcp_ports: {}
+      udp_ports: {}
+      os: []
+  192.168.56.11:
+      hostnames:
+      - winterfell.north.sevenkingdoms.local
+      tcp_ports: {}
+      udp_ports: {}
+      os: []
+  192.168.56.22:
+      hostnames:
+      - castelblack.north.sevenkingdoms.local
+      tcp_ports: {}
+      udp_ports: {}
+      os: []
+  
+  
+  '''
+# ---
+# name: test_cli_snapshot[--txt tests/data/txt/goad-light.txt -w yaml]
+  '''
+  192.168.56.10:
+      hostnames:
+      - kingslanding.sevenkingdoms.local
+      tcp_ports: {}
+      udp_ports: {}
+      os: []
+  192.168.56.11:
+      hostnames:
+      - winterfell.north.sevenkingdoms.local
+      tcp_ports: {}
+      udp_ports: {}
+      os: []
+  192.168.56.22:
+      hostnames:
+      - castelblack.north.sevenkingdoms.local
+      tcp_ports: {}
+      udp_ports: {}
+      os: []
+  
+  
+  '''
+# ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Insert src directory to sys.path to ensure local code is used
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+# pytest_plugins = ["syrupy"]

--- a/tests/smoke_tests/test_smoke.py
+++ b/tests/smoke_tests/test_smoke.py
@@ -1,11 +1,13 @@
 import os
+from io import StringIO
 from pathlib import Path
-from subprocess import run
-from sys import executable
 from tempfile import NamedTemporaryFile
+from unittest.mock import patch
 
 import pytest
 import yaml
+
+from scans2any.main import main
 
 
 @pytest.fixture
@@ -17,14 +19,34 @@ def test_env():
         project_root = test_dir.parent.parent
         data_dir = project_root / "tests/data"
 
-        def get_scans2any_command(self):
-            """Get the command to run scans2any from the development directory"""
-            return [executable, "-m", "scans2any.main"]
-
         def run_scans2any(self, args, **kwargs):
             """Run scans2any with the given arguments using the development version"""
-            cmd = self.get_scans2any_command() + args
-            return run(cmd, **kwargs)
+            stdout = StringIO()
+            stderr = StringIO()
+            stderr.fileno = lambda: 2  # type: ignore[method-assign]  # Mock fileno for os.write
+
+            class Result:
+                def __init__(self, returncode, stdout, stderr):
+                    self.returncode = returncode
+                    self.stdout = stdout
+                    self.stderr = stderr
+
+            try:
+                with (
+                    patch("sys.argv", ["scans2any", *args]),
+                    patch("sys.stdout", stdout),
+                    patch("sys.stderr", stderr),
+                    patch("os.write"),
+                ):
+                    try:
+                        main()
+                        return Result(0, stdout.getvalue(), stderr.getvalue())
+                    except SystemExit as e:
+                        return Result(e.code, stdout.getvalue(), stderr.getvalue())
+            except Exception as e:
+                return Result(
+                    1, stdout.getvalue(), stderr.getvalue() + f"\nException: {e}"
+                )
 
     return TestEnv()
 

--- a/tests/test_all_artifacts.py
+++ b/tests/test_all_artifacts.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 
+import os
+from io import StringIO
 from pathlib import Path
-from subprocess import run
-from sys import executable
+from unittest.mock import patch
 
 import pytest
+
+from scans2any.main import main
 
 # Define repository paths
 REPO_ROOT = Path(__file__).parent.parent
@@ -51,31 +54,52 @@ def test_artifact(call: str):
         f"Expected output file not found: {expected_output_path}"
     )
 
-    # Build the command
-    cmd = [
-        executable,
-        "-m",
-        "scans2any.main",
+    # Build the command arguments
+    cmd_args = [
         f"--{input_type}",
         args[1],
         "-w",
         writer_format,
     ]
     if multi_table:
-        cmd.append("--multi-table")
+        cmd_args.append("--multi-table")
     # Include any additional arguments (e.g. -c for columns) (not used in this test)
     for i, arg in enumerate(args):
         if arg == "-c" and i + 1 < len(args):
-            cmd.extend(["-c", args[i + 1]])
+            cmd_args.extend(["-c", args[i + 1]])
 
-    result = run(cmd, capture_output=True, text=True)
-    assert result.returncode == 0, (
-        f"Command failed: {cmd} {call}\nError: {result.stderr}"
+    stdout = StringIO()
+    stderr = StringIO()
+    stderr.fileno = lambda: 2  # type: ignore[method-assign]  # Mock fileno for os.write
+
+    old_cwd = os.getcwd()
+    os.chdir(REPO_ROOT)
+
+    returncode = 0
+    try:
+        with (
+            patch("sys.argv", ["scans2any", *cmd_args]),
+            patch("sys.stdout", stdout),
+            patch("sys.stderr", stderr),
+            patch("os.write"),
+        ):
+            try:
+                main()
+            except SystemExit as e:
+                returncode = e.code
+    except Exception as e:
+        returncode = 1
+        stderr.write(f"\nException: {e}")
+    finally:
+        os.chdir(old_cwd)
+
+    assert returncode == 0, (
+        f"Command failed: {cmd_args} {call}\nError: {stderr.getvalue()}"
     )
 
     with open(expected_output_path) as f:
         expected_output = f.read()
 
-    assert result.stdout.strip() == expected_output.strip(), (
-        f"Output for '{' '.join(cmd)}' doesn't match expected artifact: {expected_output_path}"
+    assert stdout.getvalue().strip() == expected_output.strip(), (
+        f"Output for '{' '.join(cmd_args)}' doesn't match expected artifact: {expected_output_path}"
     )

--- a/tests/test_database_autosave.py
+++ b/tests/test_database_autosave.py
@@ -1,0 +1,206 @@
+"""Test database auto-save functionality."""
+
+import os
+import sqlite3
+import tempfile
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from scans2any.main import main
+
+
+def run_scans2any(args: list[str]) -> tuple[int, str, str]:
+    """Helper to run scans2any main function directly and capture output."""
+    stdout = StringIO()
+    stderr = StringIO()
+    stderr.fileno = lambda: 2  # type: ignore[method-assign]  # Mock fileno for os.write
+
+    try:
+        with (
+            patch("sys.argv", ["scans2any", *args]),
+            patch("sys.stdout", stdout),
+            patch("sys.stderr", stderr),
+            patch("os.write"),
+        ):  # Mock os.write to avoid writing to actual stderr
+            try:
+                main()
+                return 0, stdout.getvalue(), stderr.getvalue()
+            except SystemExit as e:
+                return (
+                    e.code if isinstance(e.code, int) else 1,
+                    stdout.getvalue(),
+                    stderr.getvalue(),
+                )
+    except Exception as e:
+        return 1, stdout.getvalue(), stderr.getvalue() + f"\nException: {e}"
+
+
+def test_database_autosave_with_input_files():
+    """Test that database auto-saves when --project is used with input files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Change to temp directory
+        original_cwd = Path.cwd()
+        os.chdir(tmpdir)
+
+        try:
+            nmap_file = original_cwd / "tests" / "data" / "nmap" / "goad-light.xml"
+            project_name = "test-autosave"
+            db_file = Path(f"{project_name}.db")
+
+            # Run scans2any with --project and input file
+            returncode, _stdout, stderr = run_scans2any(
+                [
+                    "--nmap",
+                    str(nmap_file),
+                    "--project",
+                    project_name,
+                    "-w",
+                    "json",
+                    "-vv",
+                ]
+            )
+
+            # Check that the command succeeded
+            assert returncode == 0, f"Command failed: {stderr}"
+
+            # Check that database file was created in the temp directory
+            assert db_file.exists(), f"Database file {db_file} was not created"
+
+            # Check that "Auto-saving to Database" appears in verbose output
+            assert "Auto-saving to Database" in stderr, (
+                "Auto-save message not found in verbose output"
+            )
+
+            # Verify database contains data
+            conn = sqlite3.connect(db_file)
+            cursor = conn.cursor()
+
+            # Check hosts table exists and has data
+            cursor.execute("SELECT COUNT(*) FROM hosts")
+            host_count = cursor.fetchone()[0]
+            assert host_count > 0, "No hosts found in database"
+
+            # Check services table exists and has data
+            cursor.execute("SELECT COUNT(*) FROM services")
+            service_count = cursor.fetchone()[0]
+            assert service_count > 0, "No services found in database"
+
+            conn.close()
+
+        finally:
+            os.chdir(original_cwd)
+
+
+def test_database_no_autosave_when_loading():
+    """Test that database does NOT auto-save when only loading from database."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        original_cwd = Path.cwd()
+        os.chdir(tmpdir)
+
+        try:
+            nmap_file = original_cwd / "tests" / "data" / "nmap" / "goad-light.xml"
+            project_name = "test-no-autosave"
+            db_file = Path(f"{project_name}.db")
+
+            # First, create a database by scanning with --project
+            returncode1, _stdout1, _stderr1 = run_scans2any(
+                [
+                    "--nmap",
+                    str(nmap_file),
+                    "--project",
+                    project_name,
+                    "-w",
+                    "json",
+                ]
+            )
+            assert returncode1 == 0, "Initial scan failed"
+            assert db_file.exists(), "Database not created"
+
+            # Get modification time
+            mtime_before = db_file.stat().st_mtime
+
+            # Now load from database only (no input files)
+            returncode2, _stdout2, stderr2 = run_scans2any(
+                [
+                    "--project",
+                    project_name,
+                    "-w",
+                    "json",
+                    "-vv",
+                ]
+            )
+
+            assert returncode2 == 0, f"Database load failed: {stderr2}"
+
+            # Check that "Auto-saving to Database" does NOT appear
+            assert "Auto-saving to Database" not in stderr2, (
+                "Auto-save should not occur when only loading from database"
+            )
+
+            # Check that database was not modified
+            mtime_after = db_file.stat().st_mtime
+            assert mtime_before == mtime_after, (
+                "Database file was modified when it shouldn't have been"
+            )
+
+        finally:
+            os.chdir(original_cwd)
+
+
+def test_database_project_isolation():
+    """Test that different projects create separate database files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        original_cwd = Path.cwd()
+        os.chdir(tmpdir)
+
+        try:
+            nmap_file = original_cwd / "tests" / "data" / "nmap" / "goad-light.xml"
+            project1 = "project-one"
+            project2 = "project-two"
+
+            # Create two projects
+            for project in [project1, project2]:
+                returncode, _stdout, _stderr = run_scans2any(
+                    [
+                        "--nmap",
+                        str(nmap_file),
+                        "--project",
+                        project,
+                        "-w",
+                        "json",
+                    ]
+                )
+                assert returncode == 0, f"Failed to create project {project}"
+
+            # Check that both database files exist
+            db1 = Path(f"{project1}.db")
+            db2 = Path(f"{project2}.db")
+
+            assert db1.exists(), f"Database {db1} not created"
+            assert db2.exists(), f"Database {db2} not created"
+
+            # Verify they are separate files
+            assert db1.stat().st_size > 0, f"Database {db1} is empty"
+            assert db2.stat().st_size > 0, f"Database {db2} is empty"
+
+            # Verify each database contains data
+            for db_file in [db1, db2]:
+                conn = sqlite3.connect(db_file)
+                cursor = conn.cursor()
+
+                # Check this database has data
+                cursor.execute("SELECT COUNT(*) FROM hosts")
+                count = cursor.fetchone()[0]
+                assert count > 0, f"No hosts found in {db_file}"
+
+                conn.close()
+
+        finally:
+            os.chdir(original_cwd)
+
+
+if __name__ == "__main__":
+    test_database_autosave_with_input_files()
+    test_database_no_autosave_when_loading()
+    test_database_project_isolation()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,41 @@
+import os
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scans2any.main import main
+
+REPO_ROOT = Path(__file__).parent.parent
+ARTIFACTS_DIR = REPO_ROOT / "tests/artifacts"
+
+
+def load_test_calls() -> list[str]:
+    test_calls_path = ARTIFACTS_DIR / "test-calls.txt"
+    if not test_calls_path.exists():
+        return []
+    with open(test_calls_path) as f:
+        return [line.strip() for line in f if line.strip() and not line.startswith("#")]
+
+
+@pytest.mark.parametrize("call", load_test_calls())
+def test_cli_snapshot(call: str, snapshot):
+    args = call.split()
+
+    stdout = StringIO()
+
+    # We need to change cwd to REPO_ROOT because some tests might use relative paths
+    old_cwd = os.getcwd()
+    os.chdir(REPO_ROOT)
+
+    try:
+        with patch("sys.argv", ["scans2any", *args]), patch("sys.stdout", stdout):
+            try:
+                main()
+            except SystemExit as e:
+                assert e.code == 0
+    finally:
+        os.chdir(old_cwd)
+
+    assert stdout.getvalue() == snapshot

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,39 @@
+import pytest
+from pydantic import ValidationError
+
+from scans2any.internal import Host, Infrastructure, Service, SortedSet
+
+
+def test_service_creation():
+    s = Service(
+        port=80,
+        protocol="tcp",
+        service_names=SortedSet(["http"]),
+        banners=SortedSet(["Apache"]),
+    )
+    assert s.port == 80
+    assert "http" in s.service_names
+
+
+def test_host_creation():
+    h = Host(address={"192.168.1.1"}, hostnames=set(), os=set())
+    assert "192.168.1.1" in h.address
+
+
+def test_host_validation():
+    with pytest.raises(ValidationError):
+        Host(address=set(), hostnames=set(), os=set())
+
+
+def test_infrastructure_creation():
+    infra = Infrastructure(identifier="test")
+    assert infra.identifier == "test"
+    assert infra.hosts == []
+
+
+def test_infrastructure_add_host():
+    infra = Infrastructure()
+    h = Host(address={"1.1.1.1"}, hostnames=set(), os=set())
+    infra.add_host(h)
+    assert len(infra.hosts) == 1
+    assert infra.hosts[0].address == {"1.1.1.1"}


### PR DESCRIPTION
- Switch test_all_artifacts.py and test_smoke.py from subprocess-based execution to in-process unittest.mock patching of sys.argv/stdout/stderr, giving ~20x faster test runs
- Add conftest.py: inserts src/ into sys.path so local code is always used
- Add test_integration.py: snapshot-based parametrized CLI tests using syrupy
- Add tests/__snapshots__/test_integration.ambr: syrupy snapshot fixtures
- Add test_database_autosave.py: tests for --project auto-save behaviour (saves on scan input, skips re-save when loading from DB, project isolation)
- Add tests/unit/test_models.py: unit tests for Host, Service and Infrastructure pydantic model construction and validation